### PR TITLE
docs: add cargo license command to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ cargo test                     # Run all tests
 cargo test diff::tests         # Run tests in a specific module
 cargo test --test diff_logic   # Run a specific integration test file
 cargo test test_name           # Run a single test by name
+cargo license                  # List dependency licenses (requires: cargo install cargo-license)
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- `cargo-license` を実行し、全依存クレートのライセンスを確認
- MIT/Apache-2.0 以外のライセンスも含まれるが、すべて許容的ライセンス（ISC, BSD, Zlib, Unicode, MPL-2.0 等）で対応不要と判断
- `CLAUDE.md` の Build & Test Commands に `cargo license` を追記

Closes #1

## Test plan

- [ ] `cargo install cargo-license` 後に `cargo license` が実行できること
- [ ] CLAUDE.md のコマンド一覧に `cargo license` が記載されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)