### PR TITLE
refactor(notify): use specific PR state in notification title

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -213,8 +213,12 @@ impl App {
                                 && matches!(new_pr.state, PrState::Closed | PrState::Merged)
                                 && new_pr.role == PrRole::Author
                             {
+                                let title = match new_pr.state {
+                                    PrState::Merged => "PR merged",
+                                    _ => "PR closed",
+                                };
                                 self.pending_notifications.push(Notification {
-                                    title: "PR closed/merged".to_string(),
+                                    title: title.to_string(),
                                     body: format!("{} ({})", new_pr.title, id),
                                 });
                             }
@@ -436,7 +440,7 @@ mod tests {
         app.update(Message::PollResult(payload_from(prs2)));
 
         assert_eq!(app.pending_notifications.len(), 1);
-        assert_eq!(app.pending_notifications[0].title, "PR closed/merged");
+        assert_eq!(app.pending_notifications[0].title, "PR closed");
     }
 
     #[test]
@@ -452,7 +456,7 @@ mod tests {
         app.update(Message::PollResult(payload_from(prs2)));
 
         assert_eq!(app.pending_notifications.len(), 1);
-        assert_eq!(app.pending_notifications[0].title, "PR closed/merged");
+        assert_eq!(app.pending_notifications[0].title, "PR merged");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the generic `"PR closed/merged"` notification title with a state-specific one
- `"PR closed"` when the PR state is `Closed`, `"PR merged"` when `Merged`

## Test plan

- [x] `closed_author_pr_triggers_notification` — asserts title is `"PR closed"`
- [x] `merged_author_pr_triggers_notification` — asserts title is `"PR merged"`
- [x] All tests pass (`cargo test`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)