### PR TITLE
feat: add configurable notification events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,4 +74,4 @@ CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/confi
 
 Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, `[notify].events`
 
-`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`. Omitting `events` enables all. `enabled = false` is a global kill switch.
+`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all. `enabled = false` is a global kill switch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,4 +74,4 @@ CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/confi
 
 Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, `[notify].events`
 
-`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all. `enabled = false` is a global kill switch.
+`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all except `ci_finished` (requires Contents read PAT permission; opt-in). `enabled = false` is a global kill switch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,4 +74,4 @@ CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/confi
 
 Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, `[notify].events`
 
-`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all except `ci_finished` (requires Contents read PAT permission; opt-in). `enabled = false` is a global kill switch.
+`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all except `ci_finished` (opt-in: it issues per-PR REST calls each poll and needs `commit_statuses: read` and/or `checks: read` on the PAT). `enabled = false` is a global kill switch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,4 +74,4 @@ CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/confi
 
 Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, plus per-event toggles under `[notify]`.
 
-Per-event toggles: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. All default `true` except `ci_finished` (default `false`). Omit a key to use its default. `enabled = false` is a global kill switch (defaults to `false`). `ci_finished` is opt-in because it issues per-PR REST calls each poll and needs `commit_statuses: read` and/or `checks: read` on the PAT.
+Per-event toggles: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. All default `true` except `ci_finished` (default `false`). Omit a key to use its default. `enabled = false` is a global kill switch (defaults to `false`). `ci_finished` only controls the notification — CI status is always fetched per poll to populate the `CI` column. Token needs `commit_statuses: read` and/or `checks: read` to actually see CI state; without those scopes the calls 403/404 silently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,6 @@ Notification triggers (only after initial load, checked in `Message::PollResult`
 
 CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/config.toml`
 
-Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, `[notify].events`
+Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, plus per-event toggles under `[notify]`.
 
-`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. Omitting `events` enables all except `ci_finished` (opt-in: it issues per-PR REST calls each poll and needs `commit_statuses: read` and/or `checks: read` on the PAT). `enabled = false` is a global kill switch.
+Per-event toggles: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. All default `true` except `ci_finished` (default `false`). Omit a key to use its default. `enabled = false` is a global kill switch (defaults to `false`). `ci_finished` is opt-in because it issues per-PR REST calls each poll and needs `commit_statuses: read` and/or `checks: read` on the PAT.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,6 @@ Notification triggers (only after initial load, checked in `Message::PollResult`
 
 CLI args > env vars (`GITHUB_TOKEN`, `GITHUB_USERNAME`) > `~/.config/prtop/config.toml`
 
-Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].backend`, `[notify].exec_command`
+Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, `[notify].events`
+
+`[notify].events` accepts a list of event names: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`. Omitting `events` enables all. `enabled = false` is a global kill switch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "prtop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ enabled = true
 | `new_comment`         |    ✅    | Comment count increases on your authored PR (self-comment skip) |
 | `ci_finished`         |    ❌    | CI transitions from in-progress to success/failure (author/both) |
 
-`ci_finished` is opt-in because each poll issues per-PR REST calls to
-`/repos/{owner}/{repo}/commits/{sha}/status` and `/check-runs`. The token
-needs **Commit statuses: Read-only** and/or **Checks: Read-only** in addition
-to the base scopes. Without those scopes the per-PR calls 403/404 and CI
-notifications silently never fire.
+CI status is fetched every poll (per-PR REST calls to
+`/repos/{owner}/{repo}/commits/{sha}/status` and `/check-runs`) and shown in
+the `CI` column regardless of `ci_finished`. The token needs
+**Commit statuses: Read-only** and/or **Checks: Read-only** in addition to
+the base scopes; without them the calls 403/404 silently and the `CI` column
+shows `-` for every PR.
+
+`ci_finished` controls only whether a *notification* fires when CI
+transitions from in-progress to success/failure. It defaults off because CI
+flapping can be noisy.
 
 ## Color Scheme
 

--- a/README.md
+++ b/README.md
@@ -56,15 +56,31 @@ To enable, add to `config.toml`:
 ```toml
 [notify]
 enabled = true
+# Per-event toggles (omit any line to use its default)
+# review_requested    = true
+# pr_closed           = true
+# pr_merged           = true
+# re_review_requested = true
+# new_comment         = true
+# ci_finished         = false
 ```
 
-Events that trigger a notification:
+`enabled` is a global kill switch — defaults to `false`, so notifications stay off until you opt in. Each event has its own toggle; omit a line to fall back to the default below.
 
-| Event               | Condition                                     |
-| ------------------- | --------------------------------------------- |
-| PR closed/merged    | You are the **author**                        |
-| Review requested    | You are **not** the author                    |
-| Re-review requested | `review_decision` changed to `ReviewRequired` |
+| Event                 | Default | Condition                                                       |
+| --------------------- | :-----: | --------------------------------------------------------------- |
+| `review_requested`    |    ✅    | A new PR appears where you are **not** the author               |
+| `pr_closed`           |    ✅    | Your authored PR transitions to closed                          |
+| `pr_merged`           |    ✅    | Your authored PR is merged                                      |
+| `re_review_requested` |    ✅    | `review_decision` changes to `ReviewRequired`                   |
+| `new_comment`         |    ✅    | Comment count increases on your authored PR (self-comment skip) |
+| `ci_finished`         |    ❌    | CI transitions from in-progress to success/failure (author/both) |
+
+`ci_finished` is opt-in because each poll issues per-PR REST calls to
+`/repos/{owner}/{repo}/commits/{sha}/status` and `/check-runs`. The token
+needs **Commit statuses: Read-only** and/or **Checks: Read-only** in addition
+to the base scopes. Without those scopes the per-PR calls 403/404 and CI
+notifications silently never fire.
 
 ## Color Scheme
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,9 +17,10 @@ poll_interval_secs = 60
 #   ✅ new_comment         — Comment count increases on your authored PR
 #   ❌ ci_finished         — CI transitions from in-progress to success/failure
 #
-# `ci_finished` is opt-in because each poll issues per-PR REST calls to
-# /repos/{owner}/{repo}/commits/{sha}/status and /check-runs. Requires
-# `Commit statuses: Read-only` and/or `Checks: Read-only` on the token.
+# `ci_finished` controls only whether a notification fires on CI transitions;
+# the CI column itself is always populated. Token needs
+# `Commit statuses: Read-only` and/or `Checks: Read-only` to read CI state —
+# without them the column silently shows `-` for every PR.
 [notify]
 enabled = false
 # review_requested    = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,12 +4,30 @@ username = "myuser"
 poll_interval_secs = 60
 
 # Notifications (via OSC 9 — requires terminal support, e.g. WezTerm)
-# Events notified:
-#   - PR closed/merged (author only)
-#   - Review requested (non-author only)
-#   - Re-review requested (review_decision changed to ReviewRequired)
+#
+# `enabled` is a global kill switch — defaults to false, so notifications stay
+# off until you opt in. Each event has its own toggle below; omit a line to
+# fall back to its default.
+#
+# Defaults (✅ = on, ❌ = opt-in):
+#   ✅ review_requested    — A new PR appears where you are not the author
+#   ✅ pr_closed           — Your authored PR transitions to closed
+#   ✅ pr_merged           — Your authored PR is merged
+#   ✅ re_review_requested — review_decision changes to ReviewRequired
+#   ✅ new_comment         — Comment count increases on your authored PR
+#   ❌ ci_finished         — CI transitions from in-progress to success/failure
+#
+# `ci_finished` is opt-in because each poll issues per-PR REST calls to
+# /repos/{owner}/{repo}/commits/{sha}/status and /check-runs. Requires
+# `Commit statuses: Read-only` and/or `Checks: Read-only` on the token.
 [notify]
 enabled = false
+# review_requested    = true
+# pr_closed           = true
+# pr_merged           = true
+# re_review_requested = true
+# new_comment         = true
+# ci_finished         = false
 
 # Colors
 # Accepts named colors (case-insensitive) or #rrggbb hex.

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,6 +57,7 @@ pub struct App {
     pub notify_events: HashSet<NotifyEvent>,
     pub colors: ColorScheme,
     pub username: String,
+    ci_fallback_warned: bool,
 }
 
 impl App {
@@ -79,6 +80,7 @@ impl App {
             notify_events,
             colors,
             username,
+            ci_fallback_warned: false,
         }
     }
 
@@ -304,11 +306,12 @@ impl App {
                     .retain(|id| incoming.contains_key(id));
                 self.prs = incoming;
                 self.last_poll = Some(payload.polled_at);
-                self.poll_error = if payload.warnings.is_empty() {
-                    None
-                } else {
-                    Some(payload.warnings.join("; "))
-                };
+                if !payload.warnings.is_empty() && !self.ci_fallback_warned {
+                    self.ci_fallback_warned = true;
+                    self.poll_error = Some(payload.warnings.join("; "));
+                } else if payload.warnings.is_empty() {
+                    self.poll_error = None;
+                }
                 self.status_message = None;
 
                 if matches!(self.loading, LoadingState::Initial | LoadingState::Loading) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use ratatui::widgets::ListState;
 
 use crate::colors::ColorScheme;
+use crate::config::NotifyEvent;
 use crate::diff::diff_pr_sets;
 use crate::notify::Notification;
 use crate::poller::PollPayload;
@@ -53,12 +54,13 @@ pub struct App {
     pub dirty: bool,
     pub last_activity: Option<Instant>,
     pub pending_notifications: Vec<Notification>,
+    pub notify_events: HashSet<NotifyEvent>,
     pub colors: ColorScheme,
     pub username: String,
 }
 
 impl App {
-    pub fn new(username: String, colors: ColorScheme) -> Self {
+    pub fn new(username: String, colors: ColorScheme, notify_events: HashSet<NotifyEvent>) -> Self {
         Self {
             prs: IndexMap::new(),
             list_state: ListState::default(),
@@ -74,6 +76,7 @@ impl App {
             dirty: true,
             last_activity: None,
             pending_notifications: Vec::new(),
+            notify_events,
             colors,
             username,
         }
@@ -202,6 +205,7 @@ impl App {
                     for id in &diff.added {
                         if let Some(pr) = incoming.get(id)
                             && pr.role != PrRole::Author
+                            && self.notify_events.contains(&NotifyEvent::ReviewRequested)
                         {
                             self.pending_notifications.push(Notification {
                                 title: "Review requested".to_string(),
@@ -219,14 +223,16 @@ impl App {
                                 && matches!(new_pr.state, PrState::Closed | PrState::Merged)
                                 && new_pr.role == PrRole::Author
                             {
-                                let title = match new_pr.state {
-                                    PrState::Merged => "PR merged",
-                                    _ => "PR closed",
+                                let (title, event) = match new_pr.state {
+                                    PrState::Merged => ("PR merged", NotifyEvent::PrMerged),
+                                    _ => ("PR closed", NotifyEvent::PrClosed),
                                 };
-                                self.pending_notifications.push(Notification {
-                                    title: title.to_string(),
-                                    body: format!("{} ({})", new_pr.title, id),
-                                });
+                                if self.notify_events.contains(&event) {
+                                    self.pending_notifications.push(Notification {
+                                        title: title.to_string(),
+                                        body: format!("{} ({})", new_pr.title, id),
+                                    });
+                                }
                             }
 
                             let old_decision = old_pr.review_decision.as_ref();
@@ -237,7 +243,9 @@ impl App {
                                         old_decision,
                                         Some(ReviewDecision::ReviewRequired)
                                     );
-                            if became_review_required {
+                            if became_review_required
+                                && self.notify_events.contains(&NotifyEvent::ReReviewRequested)
+                            {
                                 self.pending_notifications.push(Notification {
                                     title: "Re-review requested".to_string(),
                                     body: format!("{} ({})", new_pr.title, id),
@@ -254,10 +262,12 @@ impl App {
                             && matches!(new_pr.role, PrRole::Author | PrRole::Both)
                             && new_pr.last_commenter.as_deref() != Some(self.username.as_str())
                         {
-                            self.pending_notifications.push(Notification {
-                                title: "New comment".to_string(),
-                                body: format!("{} ({})", new_pr.title, id),
-                            });
+                            if self.notify_events.contains(&NotifyEvent::NewComment) {
+                                self.pending_notifications.push(Notification {
+                                    title: "New comment".to_string(),
+                                    body: format!("{} ({})", new_pr.title, id),
+                                });
+                            }
                             self.new_comment_pr_ids.insert(id.clone());
                         }
                     }
@@ -401,14 +411,22 @@ mod tests {
 
     #[test]
     fn quit_sets_flag() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::Quit);
         assert!(app.should_quit);
     }
 
     #[test]
     fn poll_result_updates_prs() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollResult(make_payload(3)));
         assert_eq!(app.prs.len(), 3);
         assert!(matches!(app.loading, LoadingState::Loaded));
@@ -417,7 +435,11 @@ mod tests {
 
     #[test]
     fn navigation_wraps() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollResult(make_payload(3)));
         assert_eq!(app.list_state.selected(), None);
 
@@ -436,7 +458,11 @@ mod tests {
 
     #[test]
     fn toggle_help() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         assert_eq!(app.screen, Screen::PrList);
         app.update(Message::ToggleHelp);
         assert_eq!(app.screen, Screen::Help);
@@ -446,7 +472,11 @@ mod tests {
 
     #[test]
     fn poll_error_sets_state() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollError("network error".to_string()));
         assert!(app.poll_error.is_some());
         assert!(matches!(app.loading, LoadingState::Error(_)));
@@ -456,7 +486,11 @@ mod tests {
 
     #[test]
     fn no_notifications_on_first_poll() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -469,7 +503,11 @@ mod tests {
 
     #[test]
     fn closed_author_pr_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(id.clone(), make_pr_custom(&id, PrRole::Author, None, 0));
@@ -486,7 +524,11 @@ mod tests {
 
     #[test]
     fn merged_author_pr_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(id.clone(), make_pr_custom(&id, PrRole::Author, None, 0));
@@ -502,7 +544,11 @@ mod tests {
 
     #[test]
     fn closed_reviewer_pr_no_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -523,7 +569,11 @@ mod tests {
 
     #[test]
     fn focus_on_closed_pr_removes_it() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id_open = make_id(1);
         let id_closed = make_id(2);
 
@@ -564,7 +614,11 @@ mod tests {
 
     #[test]
     fn focus_on_merged_pr_removes_it() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id_merged = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -580,7 +634,11 @@ mod tests {
 
     #[test]
     fn added_reviewer_pr_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollResult(payload_from(IndexMap::new())));
         let id = make_id(1);
         let mut prs = IndexMap::new();
@@ -595,7 +653,11 @@ mod tests {
 
     #[test]
     fn added_author_pr_no_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollResult(payload_from(IndexMap::new())));
         let id = make_id(1);
         let mut prs = IndexMap::new();
@@ -606,7 +668,11 @@ mod tests {
 
     #[test]
     fn review_required_transition_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -639,7 +705,11 @@ mod tests {
 
     #[test]
     fn already_review_required_no_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -671,7 +741,11 @@ mod tests {
 
     #[test]
     fn dismissed_pr_does_not_reappear_after_next_poll() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id_open = make_id(1);
         let id_closed = make_id(2);
 
@@ -726,7 +800,11 @@ mod tests {
 
     #[test]
     fn dismissed_pr_reappear_does_not_trigger_review_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
 
         // Initial poll: open reviewer PR
@@ -770,7 +848,11 @@ mod tests {
     fn closed_pr_not_tracked_in_session_does_not_appear_on_subsequent_poll() {
         // Regression: closed/merged PRs that were already closed before the session started
         // must not appear in the list, even when they arrive in a subsequent poll payload.
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id_open = make_id(1);
         let id_closing = make_id(2);
         let id_already_closed = make_id(3);
@@ -817,7 +899,11 @@ mod tests {
 
     #[test]
     fn new_prs_detected() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         app.update(Message::PollResult(make_payload(2)));
         // Initial load: no markers (all PRs are "known" from the start)
         assert_eq!(app.new_pr_ids.len(), 0);
@@ -844,7 +930,11 @@ mod tests {
 
     #[test]
     fn comment_increase_on_author_pr_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -867,7 +957,11 @@ mod tests {
 
     #[test]
     fn comment_increase_on_reviewer_pr_no_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -889,7 +983,11 @@ mod tests {
 
     #[test]
     fn comment_unchanged_no_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -911,7 +1009,11 @@ mod tests {
 
     #[test]
     fn comment_increase_sets_new_comment_pr_ids() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -932,7 +1034,11 @@ mod tests {
 
     #[test]
     fn navigate_to_pr_clears_new_comment_pr_id() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -956,7 +1062,11 @@ mod tests {
 
     #[test]
     fn comment_increase_without_updated_at_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         // updated_at は固定 (0秒)、コメント数 0
@@ -980,7 +1090,11 @@ mod tests {
 
     #[test]
     fn comment_increase_on_both_role_pr_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -1002,7 +1116,11 @@ mod tests {
 
     #[test]
     fn open_selected_clears_new_comment_pr_id() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -1027,7 +1145,11 @@ mod tests {
 
     #[test]
     fn new_comment_pr_ids_pruned_when_pr_removed_from_list() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
         let mut prs = IndexMap::new();
         prs.insert(
@@ -1053,7 +1175,11 @@ mod tests {
 
     #[test]
     fn self_comment_does_not_trigger_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
 
         // First poll: baseline
@@ -1079,7 +1205,11 @@ mod tests {
 
     #[test]
     fn other_comment_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
 
         // First poll: baseline
@@ -1103,7 +1233,11 @@ mod tests {
 
     #[test]
     fn last_commenter_none_triggers_notification() {
-        let mut app = App::new("testuser".to_string(), ColorScheme::default());
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
         let id = make_id(1);
 
         // First poll: baseline
@@ -1128,5 +1262,175 @@ mod tests {
             "None last_commenter should still notify (safe fallback)"
         );
         assert_eq!(app.pending_notifications[0].title, "New comment");
+    }
+
+    // --- Notify event filter ---
+
+    fn events_except(event: NotifyEvent) -> HashSet<NotifyEvent> {
+        let mut all = NotifyEvent::all();
+        all.remove(&event);
+        all
+    }
+
+    #[test]
+    fn disabled_review_requested_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::ReviewRequested),
+        );
+        app.update(Message::PollResult(payload_from(IndexMap::new())));
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_custom(&id, PrRole::ReviewRequested, None, 0),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn disabled_pr_closed_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::PrClosed),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Author, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(id.clone(), make_closed_pr(&id, PrRole::Author, 100));
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn disabled_pr_merged_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::PrMerged),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Author, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(id.clone(), make_merged_pr(&id, PrRole::Author, 100));
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn disabled_pr_merged_still_allows_pr_closed() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::PrMerged),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Author, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(id.clone(), make_closed_pr(&id, PrRole::Author, 100));
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert_eq!(app.pending_notifications.len(), 1);
+        assert_eq!(app.pending_notifications[0].title, "PR closed");
+    }
+
+    #[test]
+    fn disabled_re_review_requested_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::ReReviewRequested),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_custom(
+                &id,
+                PrRole::ReviewRequested,
+                Some(ReviewDecision::Approved),
+                0,
+            ),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_custom(
+                &id,
+                PrRole::ReviewRequested,
+                Some(ReviewDecision::ReviewRequired),
+                100,
+            ),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn disabled_new_comment_suppresses_notification_but_keeps_highlight() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::NewComment),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_comments(&id, PrRole::Author, None, 0, 0),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_comments(&id, PrRole::Author, None, 100, 3),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(
+            app.pending_notifications.is_empty(),
+            "notification should be suppressed"
+        );
+        assert!(
+            app.new_comment_pr_ids.contains(&id),
+            "UI highlight should still be set"
+        );
+    }
+
+    #[test]
+    fn empty_events_suppresses_all_notifications() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            HashSet::new(),
+        );
+        // review requested
+        app.update(Message::PollResult(payload_from(IndexMap::new())));
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_custom(&id, PrRole::ReviewRequested, None, 0),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+        assert!(app.pending_notifications.is_empty());
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,7 +57,6 @@ pub struct App {
     pub notify_events: HashSet<NotifyEvent>,
     pub colors: ColorScheme,
     pub username: String,
-    ci_fallback_warned: bool,
 }
 
 impl App {
@@ -80,7 +79,6 @@ impl App {
             notify_events,
             colors,
             username,
-            ci_fallback_warned: false,
         }
     }
 
@@ -306,12 +304,7 @@ impl App {
                     .retain(|id| incoming.contains_key(id));
                 self.prs = incoming;
                 self.last_poll = Some(payload.polled_at);
-                if !payload.warnings.is_empty() && !self.ci_fallback_warned {
-                    self.ci_fallback_warned = true;
-                    self.poll_error = Some(payload.warnings.join("; "));
-                } else if payload.warnings.is_empty() {
-                    self.poll_error = None;
-                }
+                self.poll_error = None;
                 self.status_message = None;
 
                 if matches!(self.loading, LoadingState::Initial | LoadingState::Loading) {
@@ -426,7 +419,6 @@ mod tests {
         PollPayload {
             prs,
             polled_at: Utc::now(),
-            warnings: Vec::new(),
         }
     }
 
@@ -1524,32 +1516,6 @@ mod tests {
         prs2.insert(
             id.clone(),
             make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Failure)),
-        );
-        app.update(Message::PollResult(payload_from(prs2)));
-
-        assert_eq!(app.pending_notifications.len(), 1);
-        assert_eq!(app.pending_notifications[0].title, "CI failed");
-    }
-
-    #[test]
-    fn ci_pending_to_error_triggers_notification() {
-        let mut app = App::new(
-            "testuser".to_string(),
-            ColorScheme::default(),
-            NotifyEvent::all(),
-        );
-        let id = make_id(1);
-        let mut prs = IndexMap::new();
-        prs.insert(
-            id.clone(),
-            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Pending)),
-        );
-        app.update(Message::PollResult(payload_from(prs)));
-
-        let mut prs2 = IndexMap::new();
-        prs2.insert(
-            id.clone(),
-            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Error)),
         );
         app.update(Message::PollResult(payload_from(prs2)));
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -304,7 +304,11 @@ impl App {
                     .retain(|id| incoming.contains_key(id));
                 self.prs = incoming;
                 self.last_poll = Some(payload.polled_at);
-                self.poll_error = None;
+                self.poll_error = if payload.warnings.is_empty() {
+                    None
+                } else {
+                    Some(payload.warnings.join("; "))
+                };
                 self.status_message = None;
 
                 if matches!(self.loading, LoadingState::Initial | LoadingState::Loading) {
@@ -419,6 +423,7 @@ mod tests {
         PollPayload {
             prs,
             polled_at: Utc::now(),
+            warnings: Vec::new(),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use crate::config::NotifyEvent;
 use crate::diff::diff_pr_sets;
 use crate::notify::Notification;
 use crate::poller::PollPayload;
-use crate::types::{PrId, PrRole, PrState, PullRequest, ReviewDecision};
+use crate::types::{CiStatus, PrId, PrRole, PrState, PullRequest, ReviewDecision};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Screen {
@@ -271,6 +271,28 @@ impl App {
                             self.new_comment_pr_ids.insert(id.clone());
                         }
                     }
+
+                    // CI status change: notify author when CI transitions from in-progress to finished
+                    for (id, new_pr) in &incoming {
+                        if let Some(old_pr) = self.prs.get(id)
+                            && matches!(new_pr.role, PrRole::Author | PrRole::Both)
+                            && old_pr
+                                .ci_status
+                                .as_ref()
+                                .is_some_and(CiStatus::is_in_progress)
+                            && new_pr.ci_status.as_ref().is_some_and(CiStatus::is_finished)
+                            && self.notify_events.contains(&NotifyEvent::CiFinished)
+                        {
+                            let title = match new_pr.ci_status {
+                                Some(CiStatus::Success) => "CI passed",
+                                _ => "CI failed",
+                            };
+                            self.pending_notifications.push(Notification {
+                                title: title.to_string(),
+                                body: format!("{} ({})", new_pr.title, id),
+                            });
+                        }
+                    }
                 }
 
                 if already_loaded {
@@ -375,6 +397,7 @@ mod tests {
             review_decision,
             total_comments,
             last_commenter: None,
+            ci_status: None,
         }
     }
 
@@ -1432,5 +1455,247 @@ mod tests {
         );
         app.update(Message::PollResult(payload_from(prs)));
         assert!(app.pending_notifications.is_empty());
+    }
+
+    // --- CI finished notification ---
+
+    fn make_pr_with_ci(
+        id: &PrId,
+        role: PrRole,
+        updated_secs: i64,
+        ci_status: Option<CiStatus>,
+    ) -> PullRequest {
+        PullRequest {
+            ci_status,
+            ..make_pr_with_comments(id, role, None, updated_secs, 0)
+        }
+    }
+
+    #[test]
+    fn ci_pending_to_success_triggers_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert_eq!(app.pending_notifications.len(), 1);
+        assert_eq!(app.pending_notifications[0].title, "CI passed");
+    }
+
+    #[test]
+    fn ci_pending_to_failure_triggers_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Failure)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert_eq!(app.pending_notifications.len(), 1);
+        assert_eq!(app.pending_notifications[0].title, "CI failed");
+    }
+
+    #[test]
+    fn ci_pending_to_error_triggers_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Error)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert_eq!(app.pending_notifications.len(), 1);
+        assert_eq!(app.pending_notifications[0].title, "CI failed");
+    }
+
+    #[test]
+    fn ci_success_to_success_no_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn ci_none_to_success_no_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_with_ci(&id, PrRole::Author, 0, None));
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(
+            app.pending_notifications.is_empty(),
+            "no notification when old ci_status is None"
+        );
+    }
+
+    #[test]
+    fn ci_notification_only_for_author() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::ReviewRequested, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::ReviewRequested, 100, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(
+            app.pending_notifications.is_empty(),
+            "reviewer should not get CI notification"
+        );
+    }
+
+    #[test]
+    fn ci_notification_for_both_role() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Both, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Both, 100, Some(CiStatus::Failure)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert_eq!(app.pending_notifications.len(), 1);
+        assert_eq!(app.pending_notifications[0].title, "CI failed");
+    }
+
+    #[test]
+    fn disabled_ci_finished_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::CiFinished),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Pending)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        let mut prs2 = IndexMap::new();
+        prs2.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 100, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs2)));
+
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn ci_no_notification_on_first_poll() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_with_ci(&id, PrRole::Author, 0, Some(CiStatus::Success)),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+
+        assert!(
+            app.pending_notifications.is_empty(),
+            "no CI notification on initial load"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,33 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
 use clap::Parser;
 use serde::Deserialize;
-use std::path::PathBuf;
 
 use crate::colors::{ColorScheme, parse_color};
 use crate::error::AppError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifyEvent {
+    ReviewRequested,
+    PrClosed,
+    PrMerged,
+    ReReviewRequested,
+    NewComment,
+}
+
+impl NotifyEvent {
+    pub fn all() -> HashSet<NotifyEvent> {
+        HashSet::from([
+            NotifyEvent::ReviewRequested,
+            NotifyEvent::PrClosed,
+            NotifyEvent::PrMerged,
+            NotifyEvent::ReReviewRequested,
+            NotifyEvent::NewComment,
+        ])
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "prtop", about = "GitHub PR Live Viewer")]
@@ -21,6 +45,7 @@ struct Cli {
 #[derive(Debug, Deserialize, Default)]
 struct NotifyFileConfig {
     enabled: Option<bool>,
+    events: Option<Vec<NotifyEvent>>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -51,11 +76,19 @@ pub struct Config {
     pub username: String,
     pub poll_interval_secs: u64,
     pub notify_enabled: bool,
+    pub notify_events: HashSet<NotifyEvent>,
     pub color_scheme: ColorScheme,
 }
 
 pub(crate) fn resolve_poll_interval(cli: Option<u64>, file: Option<u64>) -> u64 {
     cli.or(file).unwrap_or(60)
+}
+
+pub(crate) fn resolve_notify_events(events: Option<Vec<NotifyEvent>>) -> HashSet<NotifyEvent> {
+    match events {
+        Some(v) => v.into_iter().collect(),
+        None => NotifyEvent::all(),
+    }
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -79,6 +112,91 @@ mod tests {
     #[test]
     fn poll_interval_defaults_to_60() {
         assert_eq!(resolve_poll_interval(None, None), 60);
+    }
+
+    // --- NotifyEvent ---
+
+    #[test]
+    fn notify_event_all_contains_every_variant() {
+        let all = NotifyEvent::all();
+        assert_eq!(all.len(), 5);
+        assert!(all.contains(&NotifyEvent::ReviewRequested));
+        assert!(all.contains(&NotifyEvent::PrClosed));
+        assert!(all.contains(&NotifyEvent::PrMerged));
+        assert!(all.contains(&NotifyEvent::ReReviewRequested));
+        assert!(all.contains(&NotifyEvent::NewComment));
+    }
+
+    #[test]
+    fn notify_event_deserialize_snake_case() {
+        let cases = [
+            ("\"review_requested\"", NotifyEvent::ReviewRequested),
+            ("\"pr_closed\"", NotifyEvent::PrClosed),
+            ("\"pr_merged\"", NotifyEvent::PrMerged),
+            ("\"re_review_requested\"", NotifyEvent::ReReviewRequested),
+            ("\"new_comment\"", NotifyEvent::NewComment),
+        ];
+        for (json, expected) in cases {
+            let parsed: NotifyEvent = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
+
+    #[test]
+    fn notify_event_deserialize_unknown_fails() {
+        let result: Result<NotifyEvent, _> = serde_json::from_str("\"unknown_event\"");
+        assert!(result.is_err());
+    }
+
+    // --- resolve_notify_events ---
+
+    #[test]
+    fn resolve_events_none_returns_all() {
+        let events = resolve_notify_events(None);
+        assert_eq!(events, NotifyEvent::all());
+    }
+
+    #[test]
+    fn resolve_events_some_returns_specified() {
+        let events = resolve_notify_events(Some(vec![
+            NotifyEvent::ReviewRequested,
+            NotifyEvent::PrClosed,
+        ]));
+        assert_eq!(events.len(), 2);
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
+        assert!(events.contains(&NotifyEvent::PrClosed));
+    }
+
+    #[test]
+    fn resolve_events_empty_returns_empty() {
+        let events = resolve_notify_events(Some(vec![]));
+        assert!(events.is_empty());
+    }
+
+    // --- TOML deserialization ---
+
+    #[test]
+    fn toml_notify_with_events() {
+        let toml_str = r#"
+            enabled = true
+            events = ["review_requested", "pr_merged"]
+        "#;
+        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.enabled, Some(true));
+        let events = parsed.events.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
+        assert!(events.contains(&NotifyEvent::PrMerged));
+    }
+
+    #[test]
+    fn toml_notify_without_events() {
+        let toml_str = r#"
+            enabled = true
+        "#;
+        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.enabled, Some(true));
+        assert!(parsed.events.is_none());
     }
 }
 
@@ -118,7 +236,9 @@ impl Config {
         let poll_interval_secs =
             resolve_poll_interval(cli.poll_interval_secs, file.poll_interval_secs);
 
-        let notify_enabled = file.notify.unwrap_or_default().enabled.unwrap_or(false);
+        let notify_file = file.notify.unwrap_or_default();
+        let notify_enabled = notify_file.enabled.unwrap_or(false);
+        let notify_events = resolve_notify_events(notify_file.events);
 
         let fc = file.colors.unwrap_or_default();
         let d = ColorScheme::default();
@@ -163,6 +283,7 @@ impl Config {
             username,
             poll_interval_secs,
             notify_enabled,
+            notify_events,
             color_scheme,
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub enum NotifyEvent {
     PrMerged,
     ReReviewRequested,
     NewComment,
+    CiFinished,
 }
 
 impl NotifyEvent {
@@ -25,6 +26,7 @@ impl NotifyEvent {
             NotifyEvent::PrMerged,
             NotifyEvent::ReReviewRequested,
             NotifyEvent::NewComment,
+            NotifyEvent::CiFinished,
         ])
     }
 }
@@ -119,12 +121,13 @@ mod tests {
     #[test]
     fn notify_event_all_contains_every_variant() {
         let all = NotifyEvent::all();
-        assert_eq!(all.len(), 5);
+        assert_eq!(all.len(), 6);
         assert!(all.contains(&NotifyEvent::ReviewRequested));
         assert!(all.contains(&NotifyEvent::PrClosed));
         assert!(all.contains(&NotifyEvent::PrMerged));
         assert!(all.contains(&NotifyEvent::ReReviewRequested));
         assert!(all.contains(&NotifyEvent::NewComment));
+        assert!(all.contains(&NotifyEvent::CiFinished));
     }
 
     #[test]
@@ -135,6 +138,7 @@ mod tests {
             ("\"pr_merged\"", NotifyEvent::PrMerged),
             ("\"re_review_requested\"", NotifyEvent::ReReviewRequested),
             ("\"new_comment\"", NotifyEvent::NewComment),
+            ("\"ci_finished\"", NotifyEvent::CiFinished),
         ];
         for (json, expected) in cases {
             let parsed: NotifyEvent = serde_json::from_str(json).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub enum NotifyEvent {
 }
 
 impl NotifyEvent {
+    /// All variants including opt-in ones. Used in tests only.
+    #[cfg(test)]
     pub fn all() -> HashSet<NotifyEvent> {
         HashSet::from([
             NotifyEvent::ReviewRequested,
@@ -27,6 +29,19 @@ impl NotifyEvent {
             NotifyEvent::ReReviewRequested,
             NotifyEvent::NewComment,
             NotifyEvent::CiFinished,
+        ])
+    }
+
+    /// Default events when `events` is not specified in config.
+    /// `CiFinished` is excluded because it requires additional PAT permissions
+    /// (Contents read) that may not be available.
+    pub fn defaults() -> HashSet<NotifyEvent> {
+        HashSet::from([
+            NotifyEvent::ReviewRequested,
+            NotifyEvent::PrClosed,
+            NotifyEvent::PrMerged,
+            NotifyEvent::ReReviewRequested,
+            NotifyEvent::NewComment,
         ])
     }
 }
@@ -89,7 +104,7 @@ pub(crate) fn resolve_poll_interval(cli: Option<u64>, file: Option<u64>) -> u64 
 pub(crate) fn resolve_notify_events(events: Option<Vec<NotifyEvent>>) -> HashSet<NotifyEvent> {
     match events {
         Some(v) => v.into_iter().collect(),
-        None => NotifyEvent::all(),
+        None => NotifyEvent::defaults(),
     }
 }
 
@@ -155,9 +170,31 @@ mod tests {
     // --- resolve_notify_events ---
 
     #[test]
-    fn resolve_events_none_returns_all() {
+    fn resolve_events_none_returns_defaults() {
         let events = resolve_notify_events(None);
-        assert_eq!(events, NotifyEvent::all());
+        assert_eq!(events, NotifyEvent::defaults());
+        assert!(!events.contains(&NotifyEvent::CiFinished));
+    }
+
+    #[test]
+    fn defaults_excludes_ci_finished() {
+        let defaults = NotifyEvent::defaults();
+        assert_eq!(defaults.len(), 5);
+        assert!(defaults.contains(&NotifyEvent::ReviewRequested));
+        assert!(defaults.contains(&NotifyEvent::PrClosed));
+        assert!(defaults.contains(&NotifyEvent::PrMerged));
+        assert!(defaults.contains(&NotifyEvent::ReReviewRequested));
+        assert!(defaults.contains(&NotifyEvent::NewComment));
+        assert!(!defaults.contains(&NotifyEvent::CiFinished));
+    }
+
+    #[test]
+    fn explicit_ci_finished_in_events_enables_it() {
+        let events = resolve_notify_events(Some(vec![
+            NotifyEvent::ReviewRequested,
+            NotifyEvent::CiFinished,
+        ]));
+        assert!(events.contains(&NotifyEvent::CiFinished));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,9 +32,10 @@ impl NotifyEvent {
         ])
     }
 
-    /// Default events when `events` is not specified in config.
+    /// Default events when individual toggles are not specified in config.
     /// `CiFinished` is excluded because it requires additional PAT permissions
-    /// (Contents read) that may not be available.
+    /// (Commit statuses / Checks read) that may not be available.
+    #[cfg(test)]
     pub fn defaults() -> HashSet<NotifyEvent> {
         HashSet::from([
             NotifyEvent::ReviewRequested,
@@ -62,7 +63,12 @@ struct Cli {
 #[derive(Debug, Deserialize, Default)]
 struct NotifyFileConfig {
     enabled: Option<bool>,
-    events: Option<Vec<NotifyEvent>>,
+    review_requested: Option<bool>,
+    pr_closed: Option<bool>,
+    pr_merged: Option<bool>,
+    re_review_requested: Option<bool>,
+    new_comment: Option<bool>,
+    ci_finished: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -101,11 +107,27 @@ pub(crate) fn resolve_poll_interval(cli: Option<u64>, file: Option<u64>) -> u64 
     cli.or(file).unwrap_or(60)
 }
 
-pub(crate) fn resolve_notify_events(events: Option<Vec<NotifyEvent>>) -> HashSet<NotifyEvent> {
-    match events {
-        Some(v) => v.into_iter().collect(),
-        None => NotifyEvent::defaults(),
+fn resolve_notify_events(notify: &NotifyFileConfig) -> HashSet<NotifyEvent> {
+    let mut events = HashSet::new();
+    if notify.review_requested.unwrap_or(true) {
+        events.insert(NotifyEvent::ReviewRequested);
     }
+    if notify.pr_closed.unwrap_or(true) {
+        events.insert(NotifyEvent::PrClosed);
+    }
+    if notify.pr_merged.unwrap_or(true) {
+        events.insert(NotifyEvent::PrMerged);
+    }
+    if notify.re_review_requested.unwrap_or(true) {
+        events.insert(NotifyEvent::ReReviewRequested);
+    }
+    if notify.new_comment.unwrap_or(true) {
+        events.insert(NotifyEvent::NewComment);
+    }
+    if notify.ci_finished.unwrap_or(false) {
+        events.insert(NotifyEvent::CiFinished);
+    }
+    events
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -170,8 +192,8 @@ mod tests {
     // --- resolve_notify_events ---
 
     #[test]
-    fn resolve_events_none_returns_defaults() {
-        let events = resolve_notify_events(None);
+    fn resolve_all_none_returns_defaults() {
+        let events = resolve_notify_events(&NotifyFileConfig::default());
         assert_eq!(events, NotifyEvent::defaults());
         assert!(!events.contains(&NotifyEvent::CiFinished));
     }
@@ -189,55 +211,75 @@ mod tests {
     }
 
     #[test]
-    fn explicit_ci_finished_in_events_enables_it() {
-        let events = resolve_notify_events(Some(vec![
-            NotifyEvent::ReviewRequested,
-            NotifyEvent::CiFinished,
-        ]));
+    fn ci_finished_true_enables_it() {
+        let cfg = NotifyFileConfig {
+            ci_finished: Some(true),
+            ..Default::default()
+        };
+        let events = resolve_notify_events(&cfg);
         assert!(events.contains(&NotifyEvent::CiFinished));
+        // Other defaults still on.
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
     }
 
     #[test]
-    fn resolve_events_some_returns_specified() {
-        let events = resolve_notify_events(Some(vec![
-            NotifyEvent::ReviewRequested,
-            NotifyEvent::PrClosed,
-        ]));
-        assert_eq!(events.len(), 2);
+    fn individual_false_disables_specific_event() {
+        let cfg = NotifyFileConfig {
+            new_comment: Some(false),
+            pr_merged: Some(false),
+            ..Default::default()
+        };
+        let events = resolve_notify_events(&cfg);
+        assert!(!events.contains(&NotifyEvent::NewComment));
+        assert!(!events.contains(&NotifyEvent::PrMerged));
         assert!(events.contains(&NotifyEvent::ReviewRequested));
         assert!(events.contains(&NotifyEvent::PrClosed));
+        assert!(events.contains(&NotifyEvent::ReReviewRequested));
     }
 
     #[test]
-    fn resolve_events_empty_returns_empty() {
-        let events = resolve_notify_events(Some(vec![]));
-        assert!(events.is_empty());
+    fn all_false_returns_empty() {
+        let cfg = NotifyFileConfig {
+            review_requested: Some(false),
+            pr_closed: Some(false),
+            pr_merged: Some(false),
+            re_review_requested: Some(false),
+            new_comment: Some(false),
+            ci_finished: Some(false),
+            ..Default::default()
+        };
+        assert!(resolve_notify_events(&cfg).is_empty());
     }
 
     // --- TOML deserialization ---
 
     #[test]
-    fn toml_notify_with_events() {
+    fn toml_notify_with_individual_toggles() {
         let toml_str = r#"
             enabled = true
-            events = ["review_requested", "pr_merged"]
+            new_comment = false
+            ci_finished = true
         "#;
         let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed.enabled, Some(true));
-        let events = parsed.events.unwrap();
-        assert_eq!(events.len(), 2);
+        assert_eq!(parsed.new_comment, Some(false));
+        assert_eq!(parsed.ci_finished, Some(true));
+        assert!(parsed.review_requested.is_none());
+
+        let events = resolve_notify_events(&parsed);
+        assert!(events.contains(&NotifyEvent::CiFinished));
+        assert!(!events.contains(&NotifyEvent::NewComment));
         assert!(events.contains(&NotifyEvent::ReviewRequested));
-        assert!(events.contains(&NotifyEvent::PrMerged));
     }
 
     #[test]
-    fn toml_notify_without_events() {
+    fn toml_notify_enabled_only_matches_defaults() {
         let toml_str = r#"
             enabled = true
         "#;
         let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed.enabled, Some(true));
-        assert!(parsed.events.is_none());
+        assert_eq!(resolve_notify_events(&parsed), NotifyEvent::defaults());
     }
 }
 
@@ -279,7 +321,7 @@ impl Config {
 
         let notify_file = file.notify.unwrap_or_default();
         let notify_enabled = notify_file.enabled.unwrap_or(false);
-        let notify_events = resolve_notify_events(notify_file.events);
+        let notify_events = resolve_notify_events(&notify_file);
 
         let fc = file.colors.unwrap_or_default();
         let d = ColorScheme::default();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -60,6 +60,7 @@ mod tests {
             review_decision: None,
             total_comments: 0,
             last_commenter: None,
+            ci_status: None,
         };
         (id, pr)
     }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -2,17 +2,19 @@ use reqwest::Client;
 use serde_json::json;
 
 use crate::error::AppError;
-use crate::github::query::{SEARCH_PRS_QUERY, SEARCH_PRS_QUERY_BASIC};
-use crate::github::types::{GraphQlResponse, PrNode};
+use crate::github::query::SEARCH_PRS_QUERY;
+use crate::github::types::{CheckRunsResponse, CombinedStatusResponse, GraphQlResponse, PrNode};
+use crate::types::CiStatus;
 
-const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+const GITHUB_API_BASE: &str = "https://api.github.com";
 const PAGE_SIZE: u64 = 50;
 pub const MAX_PAGES: u64 = 4;
 
+#[derive(Clone)]
 pub struct GitHubClient {
     client: Client,
     token: String,
-    base_url: String,
+    api_base: String,
 }
 
 impl GitHubClient {
@@ -23,56 +25,30 @@ impl GitHubClient {
                 .build()
                 .expect("failed to build HTTP client"),
             token,
-            base_url: GITHUB_GRAPHQL_URL.to_string(),
+            api_base: GITHUB_API_BASE.to_string(),
         }
     }
 
     #[cfg(test)]
-    pub fn new_with_base_url(token: String, base_url: String) -> Self {
+    pub fn new_with_base_url(token: String, api_base: String) -> Self {
         Self {
             client: Client::builder()
                 .user_agent("prtop/0.1.0")
                 .build()
                 .expect("failed to build HTTP client"),
             token,
-            base_url,
+            api_base,
         }
     }
 
-    /// Returns (nodes, used_fallback).
-    /// `used_fallback` is true when the commits field was unavailable due to
-    /// insufficient permissions and we retried with a basic query.
     pub async fn search_prs(
         &self,
         search_query: &str,
         max_pages: u64,
-    ) -> Result<(Vec<PrNode>, bool), AppError> {
-        match self
-            .search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY)
-            .await
-        {
-            Ok(nodes) => Ok((nodes, false)),
-            Err(AppError::GraphQl(msg)) if msg.contains("Resource not accessible") => {
-                // commits field requires Contents read permission which may not
-                // be available for repos where the user is only a reviewer.
-                // Fall back to the basic query without the commits field.
-                let nodes = self
-                    .search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY_BASIC)
-                    .await?;
-                Ok((nodes, true))
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    async fn search_prs_with_query(
-        &self,
-        search_query: &str,
-        max_pages: u64,
-        graphql_query: &str,
     ) -> Result<Vec<PrNode>, AppError> {
         let mut all_nodes = Vec::new();
         let mut cursor: Option<String> = None;
+        let url = format!("{}/graphql", self.api_base);
 
         for _ in 0..max_pages {
             let variables = json!({
@@ -82,13 +58,13 @@ impl GitHubClient {
             });
 
             let body = json!({
-                "query": graphql_query,
+                "query": SEARCH_PRS_QUERY,
                 "variables": variables,
             });
 
             let response = self
                 .client
-                .post(&self.base_url)
+                .post(&url)
                 .bearer_auth(&self.token)
                 .json(&body)
                 .send()
@@ -148,12 +124,142 @@ impl GitHubClient {
 
         Ok(all_nodes)
     }
+
+    /// Fetch the CI status for a commit by combining the legacy commit-status API
+    /// (`/repos/{owner}/{repo}/commits/{sha}/status`) and the check-runs API
+    /// (`/repos/{owner}/{repo}/commits/{sha}/check-runs`).
+    ///
+    /// Returns `None` when no CI is configured for the commit, when the SHA is empty,
+    /// or when the token lacks permission to read these endpoints (404/403). Other
+    /// errors propagate so they are visible to the caller.
+    pub async fn fetch_ci_status(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<Option<CiStatus>, AppError> {
+        if sha.is_empty() {
+            return Ok(None);
+        }
+
+        let combined = self.fetch_combined_status(owner, repo, sha).await?;
+        let check_runs = self.fetch_check_runs(owner, repo, sha).await?;
+
+        Ok(compute_ci_status(combined.as_ref(), check_runs.as_ref()))
+    }
+
+    async fn fetch_combined_status(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<Option<CombinedStatusResponse>, AppError> {
+        let url = format!(
+            "{}/repos/{}/{}/commits/{}/status",
+            self.api_base, owner, repo, sha
+        );
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(AppError::GraphQl(format!("{status}: {text}")));
+        }
+        Ok(Some(response.json().await?))
+    }
+
+    async fn fetch_check_runs(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<Option<CheckRunsResponse>, AppError> {
+        let url = format!(
+            "{}/repos/{}/{}/commits/{}/check-runs",
+            self.api_base, owner, repo, sha
+        );
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(AppError::GraphQl(format!("{status}: {text}")));
+        }
+        Ok(Some(response.json().await?))
+    }
+}
+
+fn compute_ci_status(
+    combined: Option<&CombinedStatusResponse>,
+    check_runs: Option<&CheckRunsResponse>,
+) -> Option<CiStatus> {
+    let combined_present = combined.is_some_and(|c| !c.statuses.is_empty());
+    let check_runs_present = check_runs.is_some_and(|cr| cr.total_count > 0);
+    if !combined_present && !check_runs_present {
+        return None;
+    }
+
+    // Pending if any check run is not completed.
+    if let Some(cr) = check_runs {
+        for run in &cr.check_runs {
+            if run.status != "completed" {
+                return Some(CiStatus::Pending);
+            }
+        }
+    }
+
+    // Pending if combined-status is still running.
+    if let Some(c) = combined
+        && combined_present
+        && c.state == "pending"
+    {
+        return Some(CiStatus::Pending);
+    }
+
+    // Failure if any check run failed (failure / cancelled / timed_out).
+    if let Some(cr) = check_runs {
+        for run in &cr.check_runs {
+            if matches!(
+                run.conclusion.as_deref(),
+                Some("failure" | "cancelled" | "timed_out")
+            ) {
+                return Some(CiStatus::Failure);
+            }
+        }
+    }
+
+    // Failure if combined-status failed/errored.
+    if let Some(c) = combined
+        && (c.state == "failure" || c.state == "error")
+    {
+        return Some(CiStatus::Failure);
+    }
+
+    Some(CiStatus::Success)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::method;
+    use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn empty_response() -> serde_json::Value {
@@ -184,20 +290,21 @@ mod tests {
     async fn returns_empty_nodes_on_empty_response() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(empty_response()))
             .mount(&server)
             .await;
 
         let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
-        let (nodes, used_fallback) = client.search_prs("author:user", MAX_PAGES).await.unwrap();
+        let nodes = client.search_prs("author:user", MAX_PAGES).await.unwrap();
         assert!(nodes.is_empty());
-        assert!(!used_fallback);
     }
 
     #[tokio::test]
     async fn returns_auth_error_on_401_without_rate_limit() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(401))
             .mount(&server)
             .await;
@@ -211,6 +318,7 @@ mod tests {
     async fn returns_auth_error_on_403_without_rate_limit() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(403))
             .mount(&server)
             .await;
@@ -224,6 +332,7 @@ mod tests {
     async fn returns_rate_limited_on_401_with_rate_remaining_zero() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(401).append_header("x-ratelimit-remaining", "0"))
             .mount(&server)
             .await;
@@ -242,6 +351,7 @@ mod tests {
     async fn returns_rate_limited_with_retry_after_header() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(403).append_header("retry-after", "30"))
             .mount(&server)
             .await;
@@ -260,6 +370,7 @@ mod tests {
     async fn returns_graphql_error_on_errors_in_body() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "errors": [{"message": "Something went wrong"}]
             })))
@@ -275,6 +386,7 @@ mod tests {
     async fn returns_graphql_error_when_no_data() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": null})),
             )
@@ -287,62 +399,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn falls_back_to_basic_query_on_resource_not_accessible() {
-        use wiremock::matchers::body_string_contains;
-
-        let server = MockServer::start().await;
-
-        // First call (full query with commits) returns "Resource not accessible" error
-        Mock::given(method("POST"))
-            .and(body_string_contains("statusCheckRollup"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "data": null,
-                "errors": [{"message": "Resource not accessible by personal access token"}]
-            })))
-            .up_to_n_times(1)
-            .mount(&server)
-            .await;
-
-        // Second call (basic query without commits) returns success
-        Mock::given(method("POST"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(empty_response()))
-            .mount(&server)
-            .await;
-
-        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
-        let (nodes, used_fallback) = client.search_prs("author:user", MAX_PAGES).await.unwrap();
-        assert!(nodes.is_empty());
-        assert!(used_fallback, "should indicate fallback was used");
-
-        let requests = server.received_requests().await.unwrap();
-        assert_eq!(requests.len(), 2, "expected 2 requests (full + fallback)");
-    }
-
-    #[tokio::test]
-    async fn non_resource_graphql_error_does_not_fallback() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "errors": [{"message": "Some other error"}]
-            })))
-            .mount(&server)
-            .await;
-
-        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
-        let result = client.search_prs("author:user", MAX_PAGES).await;
-        assert!(
-            matches!(result, Err(AppError::GraphQl(ref msg)) if msg.contains("Some other error"))
-        );
-
-        let requests = server.received_requests().await.unwrap();
-        assert_eq!(requests.len(), 1, "should not retry on non-resource error");
-    }
-
-    #[tokio::test]
     async fn stops_at_max_pages() {
         let server = MockServer::start().await;
-        // Always return hasNextPage: true to force MAX_PAGES cutoff
         Mock::given(method("POST"))
+            .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(paged_response()))
             .mount(&server)
             .await;
@@ -352,5 +412,188 @@ mod tests {
 
         let requests = server.received_requests().await.unwrap();
         assert_eq!(requests.len(), MAX_PAGES as usize);
+    }
+
+    // --- fetch_ci_status ---
+
+    #[tokio::test]
+    async fn ci_status_empty_sha_returns_none() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "").await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn ci_status_no_statuses_or_check_runs_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "pending",
+                "statuses": []
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total_count": 0,
+                "check_runs": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn ci_status_pending_check_run_returns_pending() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "success",
+                "statuses": []
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total_count": 2,
+                "check_runs": [
+                    {"status": "in_progress", "conclusion": null},
+                    {"status": "completed", "conclusion": "success"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, Some(CiStatus::Pending));
+    }
+
+    #[tokio::test]
+    async fn ci_status_all_completed_success_returns_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "success",
+                "statuses": []
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total_count": 1,
+                "check_runs": [
+                    {"status": "completed", "conclusion": "success"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, Some(CiStatus::Success));
+    }
+
+    #[tokio::test]
+    async fn ci_status_failed_check_run_returns_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "success",
+                "statuses": []
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total_count": 1,
+                "check_runs": [
+                    {"status": "completed", "conclusion": "failure"}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, Some(CiStatus::Failure));
+    }
+
+    #[tokio::test]
+    async fn ci_status_combined_failure_returns_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "failure",
+                "statuses": [{"state": "failure"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "total_count": 0,
+                "check_runs": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, Some(CiStatus::Failure));
+    }
+
+    #[tokio::test]
+    async fn ci_status_403_on_check_runs_falls_back_to_combined_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "state": "success",
+                "statuses": [{"state": "success"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, Some(CiStatus::Success));
+    }
+
+    #[tokio::test]
+    async fn ci_status_404_on_both_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/status"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/commits/abc/check-runs"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.fetch_ci_status("o", "r", "abc").await.unwrap();
+        assert_eq!(result, None);
     }
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -39,22 +39,27 @@ impl GitHubClient {
         }
     }
 
+    /// Returns (nodes, used_fallback).
+    /// `used_fallback` is true when the commits field was unavailable due to
+    /// insufficient permissions and we retried with a basic query.
     pub async fn search_prs(
         &self,
         search_query: &str,
         max_pages: u64,
-    ) -> Result<Vec<PrNode>, AppError> {
+    ) -> Result<(Vec<PrNode>, bool), AppError> {
         match self
             .search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY)
             .await
         {
-            Ok(nodes) => Ok(nodes),
+            Ok(nodes) => Ok((nodes, false)),
             Err(AppError::GraphQl(msg)) if msg.contains("Resource not accessible") => {
                 // commits field requires Contents read permission which may not
                 // be available for repos where the user is only a reviewer.
                 // Fall back to the basic query without the commits field.
-                self.search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY_BASIC)
-                    .await
+                let nodes = self
+                    .search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY_BASIC)
+                    .await?;
+                Ok((nodes, true))
             }
             Err(e) => Err(e),
         }
@@ -184,8 +189,9 @@ mod tests {
             .await;
 
         let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
-        let result = client.search_prs("author:user", MAX_PAGES).await.unwrap();
-        assert!(result.is_empty());
+        let (nodes, used_fallback) = client.search_prs("author:user", MAX_PAGES).await.unwrap();
+        assert!(nodes.is_empty());
+        assert!(!used_fallback);
     }
 
     #[tokio::test]
@@ -304,8 +310,9 @@ mod tests {
             .await;
 
         let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
-        let result = client.search_prs("author:user", MAX_PAGES).await;
-        assert!(result.is_ok(), "expected fallback to succeed: {result:?}");
+        let (nodes, used_fallback) = client.search_prs("author:user", MAX_PAGES).await.unwrap();
+        assert!(nodes.is_empty());
+        assert!(used_fallback, "should indicate fallback was used");
 
         let requests = server.received_requests().await.unwrap();
         assert_eq!(requests.len(), 2, "expected 2 requests (full + fallback)");

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -2,7 +2,7 @@ use reqwest::Client;
 use serde_json::json;
 
 use crate::error::AppError;
-use crate::github::query::SEARCH_PRS_QUERY;
+use crate::github::query::{SEARCH_PRS_QUERY, SEARCH_PRS_QUERY_BASIC};
 use crate::github::types::{GraphQlResponse, PrNode};
 
 const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
@@ -44,6 +44,28 @@ impl GitHubClient {
         search_query: &str,
         max_pages: u64,
     ) -> Result<Vec<PrNode>, AppError> {
+        match self
+            .search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY)
+            .await
+        {
+            Ok(nodes) => Ok(nodes),
+            Err(AppError::GraphQl(msg)) if msg.contains("Resource not accessible") => {
+                // commits field requires Contents read permission which may not
+                // be available for repos where the user is only a reviewer.
+                // Fall back to the basic query without the commits field.
+                self.search_prs_with_query(search_query, max_pages, SEARCH_PRS_QUERY_BASIC)
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn search_prs_with_query(
+        &self,
+        search_query: &str,
+        max_pages: u64,
+        graphql_query: &str,
+    ) -> Result<Vec<PrNode>, AppError> {
         let mut all_nodes = Vec::new();
         let mut cursor: Option<String> = None;
 
@@ -55,7 +77,7 @@ impl GitHubClient {
             });
 
             let body = json!({
-                "query": SEARCH_PRS_QUERY,
+                "query": graphql_query,
                 "variables": variables,
             });
 
@@ -256,6 +278,57 @@ mod tests {
         let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
         let result = client.search_prs("author:user", MAX_PAGES).await;
         assert!(matches!(result, Err(AppError::GraphQl(_))));
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_basic_query_on_resource_not_accessible() {
+        use wiremock::matchers::body_string_contains;
+
+        let server = MockServer::start().await;
+
+        // First call (full query with commits) returns "Resource not accessible" error
+        Mock::given(method("POST"))
+            .and(body_string_contains("statusCheckRollup"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": null,
+                "errors": [{"message": "Resource not accessible by personal access token"}]
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Second call (basic query without commits) returns success
+        Mock::given(method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(empty_response()))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.search_prs("author:user", MAX_PAGES).await;
+        assert!(result.is_ok(), "expected fallback to succeed: {result:?}");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2, "expected 2 requests (full + fallback)");
+    }
+
+    #[tokio::test]
+    async fn non_resource_graphql_error_does_not_fallback() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [{"message": "Some other error"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::new_with_base_url("token".to_string(), server.uri());
+        let result = client.search_prs("author:user", MAX_PAGES).await;
+        assert!(
+            matches!(result, Err(AppError::GraphQl(ref msg)) if msg.contains("Some other error"))
+        );
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1, "should not retry on non-resource error");
     }
 
     #[tokio::test]

--- a/src/github/query.rs
+++ b/src/github/query.rs
@@ -51,6 +51,50 @@ query($query: String!, $first: Int!, $after: String) {
 }
 "#;
 
+pub const SEARCH_PRS_QUERY_BASIC: &str = r#"
+query($query: String!, $first: Int!, $after: String) {
+  search(query: $query, type: ISSUE, first: $first, after: $after) {
+    issueCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        state
+        isDraft
+        createdAt
+        updatedAt
+        reviewDecision
+        author {
+          login
+        }
+        repository {
+          name
+          owner {
+            login
+          }
+        }
+        comments(last: 1) {
+          totalCount
+          nodes {
+            author {
+              login
+            }
+          }
+        }
+        reviewThreads {
+          totalCount
+        }
+      }
+    }
+  }
+}
+"#;
+
 pub fn author_search_query(username: &str) -> String {
     format!("is:pr is:open author:{username}")
 }

--- a/src/github/query.rs
+++ b/src/github/query.rs
@@ -16,59 +16,7 @@ query($query: String!, $first: Int!, $after: String) {
         createdAt
         updatedAt
         reviewDecision
-        author {
-          login
-        }
-        repository {
-          name
-          owner {
-            login
-          }
-        }
-        comments(last: 1) {
-          totalCount
-          nodes {
-            author {
-              login
-            }
-          }
-        }
-        reviewThreads {
-          totalCount
-        }
-        commits(last: 1) {
-          nodes {
-            commit {
-              statusCheckRollup {
-                state
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"#;
-
-pub const SEARCH_PRS_QUERY_BASIC: &str = r#"
-query($query: String!, $first: Int!, $after: String) {
-  search(query: $query, type: ISSUE, first: $first, after: $after) {
-    issueCount
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    nodes {
-      ... on PullRequest {
-        number
-        title
-        url
-        state
-        isDraft
-        createdAt
-        updatedAt
-        reviewDecision
+        headRefOid
         author {
           login
         }

--- a/src/github/query.rs
+++ b/src/github/query.rs
@@ -36,6 +36,15 @@ query($query: String!, $first: Int!, $after: String) {
         reviewThreads {
           totalCount
         }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -53,6 +53,29 @@ pub struct CommentsConnection {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct StatusCheckRollup {
+    pub state: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitData {
+    pub status_check_rollup: Option<StatusCheckRollup>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitNode {
+    pub commit: CommitData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitsConnection {
+    #[serde(default)]
+    pub nodes: Vec<CommitNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PrNode {
     pub number: u64,
     pub title: String,
@@ -66,6 +89,7 @@ pub struct PrNode {
     pub repository: RepoNode,
     pub comments: CommentsConnection,
     pub review_threads: TotalCount,
+    pub commits: CommitsConnection,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -53,29 +53,6 @@ pub struct CommentsConnection {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StatusCheckRollup {
-    pub state: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CommitData {
-    pub status_check_rollup: Option<StatusCheckRollup>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CommitNode {
-    pub commit: CommitData,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct CommitsConnection {
-    #[serde(default)]
-    pub nodes: Vec<Option<CommitNode>>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct PrNode {
     pub number: u64,
     pub title: String,
@@ -85,12 +62,12 @@ pub struct PrNode {
     pub created_at: String,
     pub updated_at: String,
     pub review_decision: Option<String>,
+    #[serde(default)]
+    pub head_ref_oid: String,
     pub author: Option<ActorNode>,
     pub repository: RepoNode,
     pub comments: CommentsConnection,
     pub review_threads: TotalCount,
-    #[serde(default)]
-    pub commits: Option<CommitsConnection>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,4 +85,28 @@ pub struct RepoNode {
 #[derive(Debug, Deserialize)]
 pub struct RepoOwnerNode {
     pub login: String,
+}
+
+// --- REST API types for CI status fetch ---
+
+#[derive(Debug, Deserialize)]
+pub struct CombinedStatusResponse {
+    pub state: String,
+    #[serde(default)]
+    pub statuses: Vec<serde::de::IgnoredAny>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CheckRunsResponse {
+    #[serde(default)]
+    pub total_count: u64,
+    #[serde(default)]
+    pub check_runs: Vec<CheckRun>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckRun {
+    pub status: String,
+    pub conclusion: Option<String>,
 }

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -71,7 +71,7 @@ pub struct CommitNode {
 #[derive(Debug, Deserialize)]
 pub struct CommitsConnection {
     #[serde(default)]
-    pub nodes: Vec<CommitNode>,
+    pub nodes: Vec<Option<CommitNode>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -89,7 +89,8 @@ pub struct PrNode {
     pub repository: RepoNode,
     pub comments: CommentsConnection,
     pub review_threads: TotalCount,
-    pub commits: CommitsConnection,
+    #[serde(default)]
+    pub commits: Option<CommitsConnection>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use app::{App, Message};
-use config::{Config, NotifyEvent};
+use config::Config;
 use github::client::GitHubClient;
 use notify::build_notifier;
 
@@ -57,7 +57,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let error_tx = msg_tx.clone();
     let username = config.username.clone();
     let interval = Duration::from_secs(config.poll_interval_secs);
-    let fetch_ci = config.notify_events.contains(&NotifyEvent::CiFinished);
 
     tokio::spawn(async move {
         let error_sender = {
@@ -87,7 +86,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             client,
             username,
             interval,
-            fetch_ci,
             poll_sender,
             error_sender,
             poll_cancel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use app::{App, Message};
-use config::Config;
+use config::{Config, NotifyEvent};
 use github::client::GitHubClient;
 use notify::build_notifier;
 
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let error_tx = msg_tx.clone();
     let username = config.username.clone();
     let interval = Duration::from_secs(config.poll_interval_secs);
+    let fetch_ci = config.notify_events.contains(&NotifyEvent::CiFinished);
 
     tokio::spawn(async move {
         let error_sender = {
@@ -86,6 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             client,
             username,
             interval,
+            fetch_ci,
             poll_sender,
             error_sender,
             poll_cancel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let notifier = build_notifier(config.notify_enabled);
 
     let mut terminal = tui::terminal::init()?;
-    let mut app = App::new(config.username.clone(), config.color_scheme.clone());
+    let mut app = App::new(
+        config.username.clone(),
+        config.color_scheme.clone(),
+        config.notify_events.clone(),
+    );
 
     // Spawn event reader
     let event_cancel = cancel.clone();

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -54,6 +54,7 @@ fn node_to_pr(node: PrNode, role: PrRole) -> PullRequest {
             .commits
             .nodes
             .first()
+            .and_then(|c| c.as_ref())
             .and_then(|c| c.commit.status_check_rollup.as_ref())
             .and_then(|r| CiStatus::from_str_opt(Some(&r.state))),
     }

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -118,12 +118,10 @@ async fn enrich_with_ci_status(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn polling_loop(
     client: GitHubClient,
     username: String,
     interval: Duration,
-    fetch_ci: bool,
     tx: mpsc::Sender<PollPayload>,
     error_tx: mpsc::Sender<String>,
     cancel: CancellationToken,
@@ -132,7 +130,7 @@ pub async fn polling_loop(
     let mut backoff_secs = 0u64;
 
     loop {
-        let result = poll_once(&client, &username, fetch_ci).await;
+        let result = poll_once(&client, &username).await;
 
         match result {
             Ok(payload) => {
@@ -177,11 +175,7 @@ pub async fn polling_loop(
     }
 }
 
-async fn poll_once(
-    client: &GitHubClient,
-    username: &str,
-    fetch_ci: bool,
-) -> Result<PollPayload, AppError> {
+async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload, AppError> {
     let author_open_query = query::author_search_query(username);
     let author_closed_query = query::author_closed_search_query(username);
     let review_open_query = query::review_requested_search_query(username);
@@ -205,9 +199,7 @@ async fn poll_once(
 
     let (mut prs, shas) = merge_and_convert(author_nodes, review_nodes);
 
-    if fetch_ci {
-        enrich_with_ci_status(client, &mut prs, shas).await;
-    }
+    enrich_with_ci_status(client, &mut prs, shas).await;
 
     Ok(PollPayload {
         prs,
@@ -417,7 +409,6 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(3600),
-                false,
                 tx,
                 err_tx,
                 cancel_clone,
@@ -460,7 +451,6 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(60),
-                false,
                 tx,
                 err_tx,
                 cancel_clone,
@@ -507,7 +497,6 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(3600),
-                false,
                 tx,
                 err_tx,
                 cancel_clone,

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -10,7 +10,7 @@ use crate::error::AppError;
 use crate::github::client::{GitHubClient, MAX_PAGES};
 use crate::github::query;
 use crate::github::types::PrNode;
-use crate::types::{PrId, PrRole, PrState, PullRequest, ReviewDecision};
+use crate::types::{CiStatus, PrId, PrRole, PrState, PullRequest, ReviewDecision};
 
 pub struct PollPayload {
     pub prs: IndexMap<PrId, PullRequest>,
@@ -50,6 +50,12 @@ fn node_to_pr(node: PrNode, role: PrRole) -> PullRequest {
             .first()
             .and_then(|c| c.author.as_ref())
             .map(|a| a.login.clone()),
+        ci_status: node
+            .commits
+            .nodes
+            .first()
+            .and_then(|c| c.commit.status_check_rollup.as_ref())
+            .and_then(|r| CiStatus::from_str_opt(Some(&r.state))),
     }
 }
 
@@ -172,7 +178,8 @@ mod tests {
     use super::*;
     use crate::github::client::GitHubClient;
     use crate::github::types::{
-        ActorNode, CommentsConnection, PrNode, RepoNode, RepoOwnerNode, TotalCount,
+        ActorNode, CommentsConnection, CommitsConnection, PrNode, RepoNode, RepoOwnerNode,
+        TotalCount,
     };
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -201,6 +208,7 @@ mod tests {
                 nodes: vec![],
             },
             review_threads: TotalCount { total_count: 0 },
+            commits: CommitsConnection { nodes: vec![] },
         }
     }
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -15,6 +15,7 @@ use crate::types::{CiStatus, PrId, PrRole, PrState, PullRequest, ReviewDecision}
 pub struct PollPayload {
     pub prs: IndexMap<PrId, PullRequest>,
     pub polled_at: DateTime<Utc>,
+    pub warnings: Vec<String>,
 }
 
 fn parse_state(s: &str) -> PrState {
@@ -160,17 +161,29 @@ async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload,
         client.search_prs(&review_closed_query, 1),
     );
 
-    let mut author_nodes = author_open?;
-    author_nodes.extend(author_closed?);
+    let (mut author_nodes, fb1) = author_open?;
+    let (author_closed_nodes, fb2) = author_closed?;
+    author_nodes.extend(author_closed_nodes);
 
-    let mut review_nodes = review_open?;
-    review_nodes.extend(review_closed?);
+    let (mut review_nodes, fb3) = review_open?;
+    let (review_closed_nodes, fb4) = review_closed?;
+    review_nodes.extend(review_closed_nodes);
+
+    let used_fallback = fb1 || fb2 || fb3 || fb4;
+    let mut warnings = Vec::new();
+    if used_fallback {
+        warnings.push(
+            "CI status unavailable: token lacks Contents read permission for some repos"
+                .to_string(),
+        );
+    }
 
     let prs = merge_and_convert(author_nodes, review_nodes);
 
     Ok(PollPayload {
         prs,
         polled_at: Utc::now(),
+        warnings,
     })
 }
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -173,8 +173,7 @@ async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload,
     let mut warnings = Vec::new();
     if used_fallback {
         warnings.push(
-            "CI status unavailable: token lacks Contents read permission for some repos"
-                .to_string(),
+            "CI status unavailable for some repos (commits field not accessible)".to_string(),
         );
     }
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -52,8 +52,8 @@ fn node_to_pr(node: PrNode, role: PrRole) -> PullRequest {
             .map(|a| a.login.clone()),
         ci_status: node
             .commits
-            .nodes
-            .first()
+            .as_ref()
+            .and_then(|commits| commits.nodes.first())
             .and_then(|c| c.as_ref())
             .and_then(|c| c.commit.status_check_rollup.as_ref())
             .and_then(|r| CiStatus::from_str_opt(Some(&r.state))),
@@ -209,7 +209,7 @@ mod tests {
                 nodes: vec![],
             },
             review_threads: TotalCount { total_count: 0 },
-            commits: CommitsConnection { nodes: vec![] },
+            commits: Some(CommitsConnection { nodes: vec![] }),
         }
     }
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,21 +1,21 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::AppError;
 use crate::github::client::{GitHubClient, MAX_PAGES};
 use crate::github::query;
 use crate::github::types::PrNode;
-use crate::types::{CiStatus, PrId, PrRole, PrState, PullRequest, ReviewDecision};
+use crate::types::{PrId, PrRole, PrState, PullRequest, ReviewDecision};
 
 pub struct PollPayload {
     pub prs: IndexMap<PrId, PullRequest>,
     pub polled_at: DateTime<Utc>,
-    pub warnings: Vec<String>,
 }
 
 fn parse_state(s: &str) -> PrState {
@@ -27,13 +27,16 @@ fn parse_state(s: &str) -> PrState {
     }
 }
 
-fn node_to_pr(node: PrNode, role: PrRole) -> PullRequest {
+/// Convert a GraphQL PR node to a domain PullRequest. `ci_status` is left `None`;
+/// it is populated by [`enrich_with_ci_status`] in a separate REST call.
+fn node_to_pr(node: PrNode, role: PrRole) -> (PullRequest, String) {
     let id = PrId {
         owner: node.repository.owner.login,
         repo: node.repository.name,
         number: node.number,
     };
-    PullRequest {
+    let head_sha = node.head_ref_oid;
+    let pr = PullRequest {
         id,
         title: node.title,
         url: node.url,
@@ -51,47 +54,76 @@ fn node_to_pr(node: PrNode, role: PrRole) -> PullRequest {
             .first()
             .and_then(|c| c.author.as_ref())
             .map(|a| a.login.clone()),
-        ci_status: node
-            .commits
-            .as_ref()
-            .and_then(|commits| commits.nodes.first())
-            .and_then(|c| c.as_ref())
-            .and_then(|c| c.commit.status_check_rollup.as_ref())
-            .and_then(|r| CiStatus::from_str_opt(Some(&r.state))),
-    }
+        ci_status: None,
+    };
+    (pr, head_sha)
 }
 
 pub fn merge_and_convert(
     author_nodes: Vec<PrNode>,
     review_nodes: Vec<PrNode>,
-) -> IndexMap<PrId, PullRequest> {
+) -> (IndexMap<PrId, PullRequest>, HashMap<PrId, String>) {
     let mut result = IndexMap::new();
+    let mut shas: HashMap<PrId, String> = HashMap::new();
 
     let mut author_ids: HashSet<PrId> = HashSet::new();
     for node in author_nodes {
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, sha) = node_to_pr(node, PrRole::Author);
         author_ids.insert(pr.id.clone());
+        shas.insert(pr.id.clone(), sha);
         result.insert(pr.id.clone(), pr);
     }
 
     for node in review_nodes {
-        let pr = node_to_pr(node, PrRole::ReviewRequested);
+        let (pr, sha) = node_to_pr(node, PrRole::ReviewRequested);
         if author_ids.contains(&pr.id) {
             if let Some(existing) = result.get_mut(&pr.id) {
                 existing.role = PrRole::Both;
             }
         } else {
+            shas.insert(pr.id.clone(), sha);
             result.insert(pr.id.clone(), pr);
         }
     }
 
-    result
+    (result, shas)
 }
 
+/// Fetch CI status for every PR in parallel and assign `ci_status`.
+/// Errors for individual PRs are swallowed (best-effort enrichment).
+async fn enrich_with_ci_status(
+    client: &GitHubClient,
+    prs: &mut IndexMap<PrId, PullRequest>,
+    shas: HashMap<PrId, String>,
+) {
+    let mut joinset: JoinSet<(PrId, Option<crate::types::CiStatus>)> = JoinSet::new();
+    for (id, sha) in shas {
+        if sha.is_empty() {
+            continue;
+        }
+        let client = client.clone();
+        joinset.spawn(async move {
+            let ci = client
+                .fetch_ci_status(&id.owner, &id.repo, &sha)
+                .await
+                .unwrap_or(None);
+            (id, ci)
+        });
+    }
+    while let Some(res) = joinset.join_next().await {
+        let Ok((id, ci)) = res else { continue };
+        if let Some(pr) = prs.get_mut(&id) {
+            pr.ci_status = ci;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn polling_loop(
     client: GitHubClient,
     username: String,
     interval: Duration,
+    fetch_ci: bool,
     tx: mpsc::Sender<PollPayload>,
     error_tx: mpsc::Sender<String>,
     cancel: CancellationToken,
@@ -100,7 +132,7 @@ pub async fn polling_loop(
     let mut backoff_secs = 0u64;
 
     loop {
-        let result = poll_once(&client, &username).await;
+        let result = poll_once(&client, &username, fetch_ci).await;
 
         match result {
             Ok(payload) => {
@@ -145,7 +177,11 @@ pub async fn polling_loop(
     }
 }
 
-async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload, AppError> {
+async fn poll_once(
+    client: &GitHubClient,
+    username: &str,
+    fetch_ci: bool,
+) -> Result<PollPayload, AppError> {
     let author_open_query = query::author_search_query(username);
     let author_closed_query = query::author_closed_search_query(username);
     let review_open_query = query::review_requested_search_query(username);
@@ -161,28 +197,21 @@ async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload,
         client.search_prs(&review_closed_query, 1),
     );
 
-    let (mut author_nodes, fb1) = author_open?;
-    let (author_closed_nodes, fb2) = author_closed?;
-    author_nodes.extend(author_closed_nodes);
+    let mut author_nodes = author_open?;
+    author_nodes.extend(author_closed?);
 
-    let (mut review_nodes, fb3) = review_open?;
-    let (review_closed_nodes, fb4) = review_closed?;
-    review_nodes.extend(review_closed_nodes);
+    let mut review_nodes = review_open?;
+    review_nodes.extend(review_closed?);
 
-    let used_fallback = fb1 || fb2 || fb3 || fb4;
-    let mut warnings = Vec::new();
-    if used_fallback {
-        warnings.push(
-            "CI status unavailable for some repos (commits field not accessible)".to_string(),
-        );
+    let (mut prs, shas) = merge_and_convert(author_nodes, review_nodes);
+
+    if fetch_ci {
+        enrich_with_ci_status(client, &mut prs, shas).await;
     }
-
-    let prs = merge_and_convert(author_nodes, review_nodes);
 
     Ok(PollPayload {
         prs,
         polled_at: Utc::now(),
-        warnings,
     })
 }
 
@@ -191,8 +220,7 @@ mod tests {
     use super::*;
     use crate::github::client::GitHubClient;
     use crate::github::types::{
-        ActorNode, CommentsConnection, CommitsConnection, PrNode, RepoNode, RepoOwnerNode,
-        TotalCount,
+        ActorNode, CommentsConnection, PrNode, RepoNode, RepoOwnerNode, TotalCount,
     };
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -207,6 +235,7 @@ mod tests {
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
             review_decision: None,
+            head_ref_oid: String::new(),
             author: Some(ActorNode {
                 login: "user".to_string(),
             }),
@@ -221,7 +250,6 @@ mod tests {
                 nodes: vec![],
             },
             review_threads: TotalCount { total_count: 0 },
-            commits: Some(CommitsConnection { nodes: vec![] }),
         }
     }
 
@@ -229,7 +257,7 @@ mod tests {
     fn merge_author_only() {
         let author = vec![make_node("org", "repo", 1)];
         let review = vec![];
-        let result = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(author, review);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
         assert_eq!(pr.role, PrRole::Author);
@@ -239,7 +267,7 @@ mod tests {
     fn merge_review_only() {
         let author = vec![];
         let review = vec![make_node("org", "repo", 1)];
-        let result = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(author, review);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
         assert_eq!(pr.role, PrRole::ReviewRequested);
@@ -249,7 +277,7 @@ mod tests {
     fn merge_both_roles() {
         let author = vec![make_node("org", "repo", 1)];
         let review = vec![make_node("org", "repo", 1)];
-        let result = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(author, review);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
         assert_eq!(pr.role, PrRole::Both);
@@ -259,7 +287,7 @@ mod tests {
     fn merge_distinct_prs() {
         let author = vec![make_node("org", "repo", 1)];
         let review = vec![make_node("org", "repo", 2)];
-        let result = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(author, review);
         assert_eq!(result.len(), 2);
     }
 
@@ -284,7 +312,7 @@ mod tests {
     fn node_to_pr_author_none_gives_empty_string() {
         let mut node = make_node("org", "repo", 1);
         node.author = None;
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(pr.author_login, "");
     }
 
@@ -293,7 +321,7 @@ mod tests {
         let mut node = make_node("org", "repo", 1);
         node.created_at = "not-a-timestamp".to_string();
         node.updated_at = "also-invalid".to_string();
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(pr.created_at, DateTime::<Utc>::default());
         assert_eq!(pr.updated_at, DateTime::<Utc>::default());
     }
@@ -302,7 +330,7 @@ mod tests {
     fn node_to_pr_unknown_review_decision() {
         let mut node = make_node("org", "repo", 1);
         node.review_decision = Some("FUTURE_DECISION".to_string());
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(
             pr.review_decision,
             Some(ReviewDecision::Unknown("FUTURE_DECISION".to_string()))
@@ -323,7 +351,7 @@ mod tests {
                 }),
             }],
         };
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(pr.last_commenter.as_deref(), Some("reviewer1"));
         assert_eq!(pr.total_comments, 5); // review_threads(0) + comments(5)
     }
@@ -331,7 +359,7 @@ mod tests {
     #[test]
     fn node_to_pr_empty_comments_gives_none() {
         let node = make_node("org", "repo", 1);
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(pr.last_commenter, None);
     }
 
@@ -343,8 +371,16 @@ mod tests {
             total_count: 2,
             nodes: vec![CommentNode { author: None }],
         };
-        let pr = node_to_pr(node, PrRole::Author);
+        let (pr, _) = node_to_pr(node, PrRole::Author);
         assert_eq!(pr.last_commenter, None);
+    }
+
+    #[test]
+    fn node_to_pr_propagates_head_sha() {
+        let mut node = make_node("org", "repo", 1);
+        node.head_ref_oid = "deadbeef".to_string();
+        let (_, sha) = node_to_pr(node, PrRole::Author);
+        assert_eq!(sha, "deadbeef");
     }
 
     // --- polling_loop async control ---
@@ -381,6 +417,7 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(3600),
+                false,
                 tx,
                 err_tx,
                 cancel_clone,
@@ -423,6 +460,7 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(60),
+                false,
                 tx,
                 err_tx,
                 cancel_clone,
@@ -469,6 +507,7 @@ mod tests {
                 client,
                 "user".to_string(),
                 Duration::from_secs(3600),
+                false,
                 tx,
                 err_tx,
                 cancel_clone,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, HighlightSpacing, List, ListItem, Paragraph};
 
 use crate::app::{App, LoadingState, Screen};
-use crate::types::{PrRole, PrState};
+use crate::types::{CiStatus, PrRole, PrState};
 
 pub fn view(f: &mut Frame, app: &mut App) {
     match app.screen {
@@ -14,15 +14,16 @@ pub fn view(f: &mut Frame, app: &mut App) {
     }
 }
 
-/// Returns (role, status, number, repo, title) column widths based on actual PR data lengths.
-/// Layout: [▸ ][role][  ][status][  ][number][title][  ][repo]
-fn col_widths(term_width: u16, app: &App) -> (usize, usize, usize, usize, usize) {
+/// Returns (role, status, ci, number, repo, title) column widths based on actual PR data lengths.
+/// Layout: [▸ ][role][  ][status][  ][ci][  ][number][title][  ][repo]
+fn col_widths(term_width: u16, app: &App) -> (usize, usize, usize, usize, usize, usize) {
     let effective = (term_width as usize).saturating_sub(2); // 2 for "▸ " / "  "
     let role: usize = 6; // "AUTHOR", "REVIEW", "BOTH  "
     let status: usize = 6; // "OPEN  ", "CLOSED", "MERGED"
+    let ci: usize = 3; // "✓  ", "×  ", "...", "-  "
     let number: usize = 7; // "#12345 "
-    let seps: usize = 6; // "  " after role, after status, after title
-    let fixed = role + status + seps + number;
+    let seps: usize = 8; // "  " after role/status/ci/title
+    let fixed = role + status + ci + seps + number;
     let remaining = effective.saturating_sub(fixed);
 
     let max_repo = app
@@ -45,7 +46,7 @@ fn col_widths(term_width: u16, app: &App) -> (usize, usize, usize, usize, usize)
         let title = remaining.saturating_sub(repo);
         (repo, title)
     };
-    (role, status, number, repo, title)
+    (role, status, ci, number, repo, title)
 }
 
 fn pr_list_area(f: &Frame, app: &App) -> Rect {
@@ -113,9 +114,9 @@ fn render_col_header(
     f: &mut Frame,
     app: &App,
     area: Rect,
-    widths: (usize, usize, usize, usize, usize),
+    widths: (usize, usize, usize, usize, usize, usize),
 ) {
-    let (role_w, status_w, num_w, repo_w, title_w) = widths;
+    let (role_w, status_w, ci_w, num_w, repo_w, title_w) = widths;
     let style = Style::default()
         .fg(app.colors.col_header)
         .add_modifier(Modifier::BOLD);
@@ -124,6 +125,8 @@ fn render_col_header(
         Span::styled(format!("{:<width$}", "ROLE", width = role_w), style),
         Span::raw("  "),
         Span::styled(format!("{:<width$}", "STATUS", width = status_w), style),
+        Span::raw("  "),
+        Span::styled(format!("{:<width$}", "CI", width = ci_w), style),
         Span::raw("  "),
         Span::styled(format!("{:<width$}", "#", width = num_w), style),
         Span::styled(format!("{:<width$}", "TITLE", width = title_w), style),
@@ -137,7 +140,7 @@ fn render_list(
     f: &mut Frame,
     app: &mut App,
     area: Rect,
-    widths: (usize, usize, usize, usize, usize),
+    widths: (usize, usize, usize, usize, usize, usize),
 ) {
     match &app.loading {
         LoadingState::Initial | LoadingState::Loading => {
@@ -160,7 +163,7 @@ fn render_list(
         return;
     }
 
-    let (role_w, status_w, num_w, repo_w, title_w) = widths;
+    let (role_w, status_w, ci_w, num_w, repo_w, title_w) = widths;
 
     let items: Vec<ListItem> = app
         .prs
@@ -194,6 +197,7 @@ fn render_list(
                 Style::default()
             };
 
+            let (ci_tag, ci_style) = ci_cell(pr.ci_status.as_ref());
             let line = Line::from(vec![
                 Span::styled(
                     format!("{:<width$}", role_tag, width = role_w),
@@ -204,6 +208,8 @@ fn render_list(
                     format!("{:<width$}", status_tag, width = status_w),
                     status_style,
                 ),
+                Span::raw("  "),
+                Span::styled(format!("{:<width$}", ci_tag, width = ci_w), ci_style),
                 Span::raw("  "),
                 Span::styled(
                     format!("{:<width$}", number_display, width = num_w),
@@ -286,6 +292,15 @@ fn render_help(f: &mut Frame, _app: &mut App) {
 
     let help = Paragraph::new(help_text).block(Block::default().title(" Help "));
     f.render_widget(help, f.area());
+}
+
+fn ci_cell(ci: Option<&CiStatus>) -> (&'static str, Style) {
+    match ci {
+        Some(CiStatus::Pending) => ("...", Style::default().fg(Color::Yellow)),
+        Some(CiStatus::Success) => ("✓", Style::default().fg(Color::Green)),
+        Some(CiStatus::Failure) => ("✗", Style::default().fg(Color::Red)),
+        None => ("-", Style::default().fg(Color::DarkGray)),
+    }
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,39 @@ impl ReviewDecision {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiStatus {
+    Pending,
+    Success,
+    Failure,
+    Error,
+    Expected,
+}
+
+impl CiStatus {
+    pub fn from_str_opt(s: Option<&str>) -> Option<Self> {
+        s.map(|s| match s {
+            "PENDING" => CiStatus::Pending,
+            "SUCCESS" => CiStatus::Success,
+            "FAILURE" => CiStatus::Failure,
+            "ERROR" => CiStatus::Error,
+            "EXPECTED" => CiStatus::Expected,
+            _ => CiStatus::Pending,
+        })
+    }
+
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self, CiStatus::Pending | CiStatus::Expected)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        matches!(
+            self,
+            CiStatus::Success | CiStatus::Failure | CiStatus::Error
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PullRequest {
     pub id: PrId,
@@ -62,6 +95,7 @@ pub struct PullRequest {
     pub review_decision: Option<ReviewDecision>,
     pub total_comments: u64,
     pub last_commenter: Option<String>,
+    pub ci_status: Option<CiStatus>,
 }
 
 #[cfg(test)]
@@ -109,5 +143,59 @@ mod tests {
             number: 42,
         };
         assert_eq!(id.to_string(), "org/repo#42");
+    }
+
+    // --- CiStatus ---
+
+    #[test]
+    fn ci_status_none_input() {
+        assert_eq!(CiStatus::from_str_opt(None), None);
+    }
+
+    #[test]
+    fn ci_status_known_values() {
+        assert_eq!(
+            CiStatus::from_str_opt(Some("PENDING")),
+            Some(CiStatus::Pending)
+        );
+        assert_eq!(
+            CiStatus::from_str_opt(Some("SUCCESS")),
+            Some(CiStatus::Success)
+        );
+        assert_eq!(
+            CiStatus::from_str_opt(Some("FAILURE")),
+            Some(CiStatus::Failure)
+        );
+        assert_eq!(CiStatus::from_str_opt(Some("ERROR")), Some(CiStatus::Error));
+        assert_eq!(
+            CiStatus::from_str_opt(Some("EXPECTED")),
+            Some(CiStatus::Expected)
+        );
+    }
+
+    #[test]
+    fn ci_status_unknown_defaults_to_pending() {
+        assert_eq!(
+            CiStatus::from_str_opt(Some("WHATEVER")),
+            Some(CiStatus::Pending)
+        );
+    }
+
+    #[test]
+    fn ci_status_in_progress() {
+        assert!(CiStatus::Pending.is_in_progress());
+        assert!(CiStatus::Expected.is_in_progress());
+        assert!(!CiStatus::Success.is_in_progress());
+        assert!(!CiStatus::Failure.is_in_progress());
+        assert!(!CiStatus::Error.is_in_progress());
+    }
+
+    #[test]
+    fn ci_status_finished() {
+        assert!(CiStatus::Success.is_finished());
+        assert!(CiStatus::Failure.is_finished());
+        assert!(CiStatus::Error.is_finished());
+        assert!(!CiStatus::Pending.is_finished());
+        assert!(!CiStatus::Expected.is_finished());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,31 +51,15 @@ pub enum CiStatus {
     Pending,
     Success,
     Failure,
-    Error,
-    Expected,
 }
 
 impl CiStatus {
-    pub fn from_str_opt(s: Option<&str>) -> Option<Self> {
-        s.map(|s| match s {
-            "PENDING" => CiStatus::Pending,
-            "SUCCESS" => CiStatus::Success,
-            "FAILURE" => CiStatus::Failure,
-            "ERROR" => CiStatus::Error,
-            "EXPECTED" => CiStatus::Expected,
-            _ => CiStatus::Pending,
-        })
-    }
-
     pub fn is_in_progress(&self) -> bool {
-        matches!(self, CiStatus::Pending | CiStatus::Expected)
+        matches!(self, CiStatus::Pending)
     }
 
     pub fn is_finished(&self) -> bool {
-        matches!(
-            self,
-            CiStatus::Success | CiStatus::Failure | CiStatus::Error
-        )
+        matches!(self, CiStatus::Success | CiStatus::Failure)
     }
 }
 
@@ -148,54 +132,16 @@ mod tests {
     // --- CiStatus ---
 
     #[test]
-    fn ci_status_none_input() {
-        assert_eq!(CiStatus::from_str_opt(None), None);
-    }
-
-    #[test]
-    fn ci_status_known_values() {
-        assert_eq!(
-            CiStatus::from_str_opt(Some("PENDING")),
-            Some(CiStatus::Pending)
-        );
-        assert_eq!(
-            CiStatus::from_str_opt(Some("SUCCESS")),
-            Some(CiStatus::Success)
-        );
-        assert_eq!(
-            CiStatus::from_str_opt(Some("FAILURE")),
-            Some(CiStatus::Failure)
-        );
-        assert_eq!(CiStatus::from_str_opt(Some("ERROR")), Some(CiStatus::Error));
-        assert_eq!(
-            CiStatus::from_str_opt(Some("EXPECTED")),
-            Some(CiStatus::Expected)
-        );
-    }
-
-    #[test]
-    fn ci_status_unknown_defaults_to_pending() {
-        assert_eq!(
-            CiStatus::from_str_opt(Some("WHATEVER")),
-            Some(CiStatus::Pending)
-        );
-    }
-
-    #[test]
     fn ci_status_in_progress() {
         assert!(CiStatus::Pending.is_in_progress());
-        assert!(CiStatus::Expected.is_in_progress());
         assert!(!CiStatus::Success.is_in_progress());
         assert!(!CiStatus::Failure.is_in_progress());
-        assert!(!CiStatus::Error.is_in_progress());
     }
 
     #[test]
     fn ci_status_finished() {
         assert!(CiStatus::Success.is_finished());
         assert!(CiStatus::Failure.is_finished());
-        assert!(CiStatus::Error.is_finished());
         assert!(!CiStatus::Pending.is_finished());
-        assert!(!CiStatus::Expected.is_finished());
     }
 }

--- a/tests/diff_logic.rs
+++ b/tests/diff_logic.rs
@@ -24,6 +24,7 @@ fn make_pr(owner: &str, repo: &str, number: u64, updated_secs: i64) -> (PrId, Pu
         review_decision: None,
         total_comments: 0,
         last_commenter: None,
+        ci_status: None,
     };
     (id, pr)
 }

--- a/tests/fixtures/search_response.json
+++ b/tests/fixtures/search_response.json
@@ -31,7 +31,12 @@
               { "author": { "login": "reviewer1" } }
             ]
           },
-          "reviewThreads": { "totalCount": 1 }
+          "reviewThreads": { "totalCount": 1 },
+          "commits": {
+            "nodes": [
+              { "commit": { "statusCheckRollup": { "state": "SUCCESS" } } }
+            ]
+          }
         },
         {
           "number": 5678,
@@ -52,7 +57,12 @@
             }
           },
           "comments": { "totalCount": 0 },
-          "reviewThreads": { "totalCount": 0 }
+          "reviewThreads": { "totalCount": 0 },
+          "commits": {
+            "nodes": [
+              { "commit": { "statusCheckRollup": null } }
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Add `NotifyEvent` enum with 5 variants (`review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`)
- Add `[notify].events` config field to let users specify which notification events to receive
- Omitting `events` enables all notifications (backward compatible)
- `pr_closed` and `pr_merged` are independently controllable
- UI highlights (`new_comment_pr_ids`) are preserved even when `new_comment` notification is disabled

## Config example

```toml
[notify]
enabled = true
events = ["review_requested", "new_comment"]
```

## Test plan

- [x] `NotifyEvent::all()` returns all 5 variants
- [x] serde deserialization works for all snake_case event names
- [x] Unknown event name fails deserialization
- [x] `resolve_notify_events(None)` returns all events
- [x] `resolve_notify_events(Some([...]))` returns specified subset
- [x] `resolve_notify_events(Some([]))` returns empty set
- [x] TOML parsing with and without `events` field
- [x] Each event type suppressed when disabled
- [x] `pr_merged` disabled still allows `pr_closed`
- [x] `new_comment` disabled still sets UI highlight
- [x] Empty events set suppresses all notifications
- [x] All 79 existing tests still pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)