### PR TITLE
Restrict release CI to tags on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag $GITHUB_REF is not on main; aborting release."
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: publish


### PR DESCRIPTION
## Summary
- Adds a guard step to `release.yml` that aborts the publish job unless the tagged commit is an ancestor of `origin/main`.
- Previously any `v*` tag, regardless of branch, would publish to crates.io.

## Test plan
- [x] Push a `v*` tag from a feature branch — release job should fail at the guard step
- [ ] Push a `v*` tag from main — release job should proceed