### PR TITLE
ci: add Dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+    groups:
+      rust-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Introduce automated dependency management with Dependabot and an auto-merge workflow.

- **`.github/dependabot.yml`** — weekly update checks for both `cargo` and `github-actions` ecosystems. Minor/patch bumps are grouped into single PRs to reduce noise (limit: 5 open PRs each).
- **`.github/workflows/dependabot-auto-merge.yml`** — enables auto-merge (squash) for Dependabot PRs, but **only for non-major updates**. Major bumps are left for manual review.

## Repository settings applied alongside this PR

- "Allow auto-merge" enabled on the repo.
- `main` branch protection with required status checks: `Lint & Format`, `Test (ubuntu-latest)`, `Test (macos-latest)` (strict mode). Auto-merge only fires after CI is green.

## Notes

- No required PR reviews, so Dependabot PRs can merge unattended.
- The workflow's explicit `permissions` block grants the write access the default read-only token lacks.