### PR TITLE
feat: add --version/-V flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ impl NotifyEvent {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "prtop", about = "GitHub PR Live Viewer")]
+#[command(name = "prt", version, about = "GitHub PR Live Viewer")]
 struct Cli {
     #[arg(long, env = "PRTOP_GITHUB_TOKEN")]
     github_token: Option<String>,


### PR DESCRIPTION
## Summary

Adds a version flag to the CLI so `prt --version` (and `-V`) report the binary version.

- Enable clap's built-in `version` flag in the `#[command(...)]` attribute
- Align the command `name` with the actual binary name (`prt`), so the output reads `prt 0.1.3` instead of `prtop 0.1.3`

Closes #23

## Verification

```
$ prt --version
prt 0.1.3
$ prt -V
prt 0.1.3
```

`cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (219 passed) all green.

## Note

The issue requested a lowercase `-v` alias, but this uses clap's standard `-V` (uppercase) to follow CLI convention (`-v` is conventionally reserved for verbose). Discussed and agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)