### PR TITLE
deps: bump aws-lc-rs to fix aws-lc-sys X.509 name constraints bypass (GHSA-394x-vwmw-crm3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## What

Bumps `aws-lc-rs` 1.16.1 → 1.17.0, which transitively pulls `aws-lc-sys` 0.38.0 → 0.41.0. Only `Cargo.lock` changes; `Cargo.toml` is untouched.

## Why

Dependabot alert #1 (GHSA-394x-vwmw-crm3 / RUSTSEC-2026-0044, high severity): a logic error in CN validation lets certificates with wildcard or raw UTF-8 Unicode CN values bypass name constraints enforcement. Affects `aws-lc-sys` `>= 0.32.0, < 0.39.0`; fixed in 0.39.0.

`aws-lc-sys` is a transitive dependency only (prtop → reqwest → rustls / quinn-proto → aws-lc-rs → aws-lc-sys). Dependabot could not open a fix PR on its own because bumping `aws-lc-sys` alone is blocked by its parent's constraint (`aws-lc-rs 1.16.1` requires `aws-lc-sys = "^0.38.0"`). Bumping the parent `aws-lc-rs` resolves it.

## Verification

- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅
- `aws-lc-sys` now 0.41.0 (≥ 0.39.0 patched version) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)