### PR TITLE
deps: bump rand to 0.9.3 to fix unsoundness advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1892,7 +1892,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#7](https://github.com/sg004baa/prtop/security/dependabot/7) (`rand` is unsound with a custom logger using `rand::rng()`).

Lockfile-only bump of the transitive `rand` dependency from **0.9.2 → 0.9.3**. The vulnerable range is `>= 0.9.0, < 0.9.3`; `0.9.3` is the first patched release.

`rand` is not a direct dependency — it is pulled in transitively (via `proptest` and TLS-related crates), so only `Cargo.lock` changes.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (219 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)