### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Lint & Format


### PR DESCRIPTION
Potential fix for [https://github.com/sg004baa/prtop/security/code-scanning/1](https://github.com/sg004baa/prtop/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege access by default. For this workflow, the best minimal non-breaking setting is:

- `contents: read`

This is sufficient for `actions/checkout` and does not alter existing workflow behavior (lint/test only). Place the block at the workflow root (after `on:` section and before `jobs:`) so both `check` and `test` jobs are covered without duplicating config.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
