### PR TITLE
feat: add mentioned PRs to the list and notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ cargo test
 
 ## Architecture
 
-Terminal-resident TUI app that monitors GitHub PRs you're involved in (as author or reviewer), using The Elm Architecture (TEA) pattern.
+Terminal-resident TUI app that monitors GitHub PRs you're involved in (as author, reviewer, or mentioned user), using The Elm Architecture (TEA) pattern.
 
 ### Async Task Model
 
@@ -47,7 +47,11 @@ The main loop only redraws when `app.dirty` is true. `CancellationToken` coordin
 
 ### GitHub API (github/)
 
-Two GraphQL search queries (`author:{user}` and `review-requested:{user}`) are executed in parallel via `tokio::join!`, then merged in `poller::merge_and_convert()`. Same PR appearing in both queries gets `PrRole::Both`. Pagination follows `endCursor` up to 4 pages (200 items max).
+Three GraphQL search queries (`author:{user}`, `review-requested:{user}`, `mentions:{user}`), each with an open and a closed variant (six searches total), are executed in parallel via `tokio::join!`, then merged in `poller::merge_and_convert()`. A PR appearing in multiple queries resolves its role by priority `Author > ReviewRequested > Mentioned`. Pagination follows `endCursor` up to 4 pages (200 items max).
+
+### Mention Dismissals (dismiss.rs)
+
+Mentioned-role PRs are dismissed when opened in the browser (`Message::OpenSelected`): `App.pending_dismissals` is drained by the main loop into `DismissStore`, persisted at `<cache_dir>/prtop/dismissed.json` (`{"owner/repo#123": "<RFC3339>"}`). The poller hides still-dismissed mentioned PRs, prunes entries no longer returned by the mentions queries, and un-dismisses a PR when a newer issue comment by someone else contains `@username` (checked via `fetch_recent_comments`, an alias-batched GraphQL query; review-thread comments are out of scope). The store is shared as `Arc<std::sync::Mutex<DismissStore>>`; locks are never held across `.await`.
 
 ### Error Classification (error.rs)
 
@@ -59,7 +63,8 @@ Two GraphQL search queries (`author:{user}` and `review-requested:{user}`) are e
 
 Notification triggers (only after initial load, checked in `Message::PollResult` handler):
 - `removed` + `role == Author` → "PR closed/merged"
-- `added` + `role != Author` → "Review requested"
+- `added` + `role == ReviewRequested` → "Review requested"
+- `added` + `role == Mentioned` → "Mentioned in PR"
 - `updated` + `review_decision` changed to `ReviewRequired` → "Re-review requested"
 
 ### Key Data Structures
@@ -74,4 +79,4 @@ CLI args > env vars (`PRTOP_GITHUB_TOKEN`, `PRTOP_GITHUB_USERNAME`) > `~/.config
 
 Config keys: `github_token`, `username`, `poll_interval_secs`, `[notify].enabled`, plus per-event toggles under `[notify]`.
 
-Per-event toggles: `review_requested`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. All default `true` except `ci_finished` (default `false`). Omit a key to use its default. `enabled = false` is a global kill switch (defaults to `false`). `ci_finished` only controls the notification — CI status is always fetched per poll to populate the `CI` column. Token needs `commit_statuses: read` and/or `checks: read` to actually see CI state; without those scopes the calls 403/404 silently.
+Per-event toggles: `review_requested`, `mentioned`, `pr_closed`, `pr_merged`, `re_review_requested`, `new_comment`, `ci_finished`. All default `true` except `ci_finished` (default `false`). Omit a key to use its default. `enabled = false` is a global kill switch (defaults to `false`). `ci_finished` only controls the notification — CI status is always fetched per poll to populate the `CI` column. Token needs `commit_statuses: read` and/or `checks: read` to actually see CI state; without those scopes the calls 403/404 silently.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # prtop
 
-A terminal-resident TUI that monitors GitHub pull requests you're involved in as author or reviewer, updating in real time via periodic polling.
+A terminal-resident TUI that monitors GitHub pull requests you're involved in as author, reviewer, or mentioned user, updating in real time via periodic polling.
 
 ![](<スクリーンショット 2026-03-21 144858.png>)
 
 ## Features
 
-- Lists PRs where you are the author or a requested reviewer, with status (Open/Closed/Merged)
+- Lists PRs where you are the author, a requested reviewer, or mentioned, with status (Open/Closed/Merged)
 - Auto-refreshes on a configurable interval
-- Terminal notifications on key events (merged, review requested, re-review requested)
+- Terminal notifications on key events (merged, review requested, re-review requested, mentioned)
 - Keyboard navigation with browser open on Enter
+- Mentioned PRs disappear once opened and come back only when you are mentioned again
 - Compact inline display — fits alongside other terminal panes
 
 ## Platform Support
@@ -67,6 +68,7 @@ To enable, add to `config.toml`:
 enabled = true
 # Per-event toggles (omit any line to use its default)
 # review_requested    = true
+# mentioned           = true
 # pr_closed           = true
 # pr_merged           = true
 # re_review_requested = true
@@ -78,12 +80,13 @@ enabled = true
 
 | Event                 | Default | Condition                                                       |
 | --------------------- | :-----: | --------------------------------------------------------------- |
-| `review_requested`    |    ✅    | A new PR appears where you are **not** the author               |
+| `review_requested`    |    ✅    | A new PR appears where review is requested from you             |
+| `mentioned`           |    ✅    | A new PR appears where you are mentioned                        |
 | `pr_closed`           |    ✅    | Your authored PR transitions to closed                          |
 | `pr_merged`           |    ✅    | Your authored PR is merged                                      |
 | `re_review_requested` |    ✅    | `review_decision` changes to `ReviewRequired`                   |
 | `new_comment`         |    ✅    | Comment count increases on your authored PR (self-comment skip) |
-| `ci_finished`         |    ❌    | CI transitions from in-progress to success/failure (author/both) |
+| `ci_finished`         |    ❌    | CI transitions from in-progress to success/failure (author only) |
 
 CI status is fetched every poll (per-PR REST calls to
 `/repos/{owner}/{repo}/commits/{sha}/status` and `/check-runs`) and shown in
@@ -96,6 +99,14 @@ shows `-` for every PR.
 transitions from in-progress to success/failure. It defaults off because CI
 flapping can be noisy.
 
+## Mentions
+
+PRs where you are mentioned (GitHub search `mentions:{username}`) show up with the
+`MENTION` role. Opening a mentioned PR in the browser dismisses it from the list;
+it reappears (with a notification) only when someone else mentions you again in an
+issue comment on that PR. Dismissals are persisted in
+`<cache_dir>/prtop/dismissed.json` (e.g. `~/.cache/prtop/dismissed.json`).
+
 ## Color Scheme
 
 All UI colors can be customized in `config.toml`:
@@ -104,7 +115,7 @@ All UI colors can be customized in `config.toml`:
 [colors]
 app_title    = "cyan"         # "GitHub PR Live" in header
 col_header   = "dark_gray"    # column header row
-role         = "cyan"         # AUTHOR / REVIEW / BOTH
+role         = "cyan"         # AUTHOR / REVIEW / MENTION
 number       = "yellow"       # #1234
 repo         = "blue"         # org/repo
 new_pr       = "green"        # newly appeared PRs

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,8 @@ poll_interval_secs = 60
 # fall back to its default.
 #
 # Defaults (✅ = on, ❌ = opt-in):
-#   ✅ review_requested    — A new PR appears where you are not the author
+#   ✅ review_requested    — A new PR appears where review is requested from you
+#   ✅ mentioned           — A new PR appears where you are mentioned
 #   ✅ pr_closed           — Your authored PR transitions to closed
 #   ✅ pr_merged           — Your authored PR is merged
 #   ✅ re_review_requested — review_decision changes to ReviewRequired
@@ -21,9 +22,13 @@ poll_interval_secs = 60
 # the CI column itself is always populated. Token needs
 # `Commit statuses: Read-only` and/or `Checks: Read-only` to read CI state —
 # without them the column silently shows `-` for every PR.
+# Mentioned PRs are hidden once opened in the browser (persisted in
+# <cache_dir>/prtop/dismissed.json, e.g. ~/.cache/prtop/dismissed.json) and
+# come back only when someone mentions you again on them.
 [notify]
 enabled = false
 # review_requested    = true
+# mentioned           = true
 # pr_closed           = true
 # pr_merged           = true
 # re_review_requested = true
@@ -36,7 +41,7 @@ enabled = false
 [colors]
 app_title    = "cyan"      # "GitHub PR Live" in header
 col_header   = "dark_gray" # ROLE / # / TITLE / REPO column headers
-role         = "cyan"      # AUTHOR / REVIEW / BOTH
+role         = "cyan"      # AUTHOR / REVIEW / MENTION
 number       = "yellow"    # #1234
 repo         = "blue"      # org/repo
 new_pr       = "green"     # newly appeared PRs

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,6 +54,9 @@ pub struct App {
     pub dirty: bool,
     pub last_activity: Option<Instant>,
     pub pending_notifications: Vec<Notification>,
+    /// ブラウザで開いて既読扱いになった Mentioned PR。main ループが drain して
+    /// DismissStore へ永続化する(pending_notifications と同じ drain パターン)。
+    pub pending_dismissals: Vec<PrId>,
     pub notify_events: HashSet<NotifyEvent>,
     pub colors: ColorScheme,
     pub username: String,
@@ -76,6 +79,7 @@ impl App {
             dirty: true,
             last_activity: None,
             pending_notifications: Vec::new(),
+            pending_dismissals: Vec::new(),
             notify_events,
             colors,
             username,
@@ -148,14 +152,28 @@ impl App {
                 if let Some(i) = self.list_state.selected()
                     && let Some((id, pr)) = self.prs.get_index(i)
                 {
-                    let removed_new = self.new_pr_ids.remove(id);
-                    let removed_comment = self.new_comment_pr_ids.remove(id);
+                    let id = id.clone();
+                    let removed_new = self.new_pr_ids.remove(&id);
+                    let removed_comment = self.new_comment_pr_ids.remove(&id);
                     if removed_new || removed_comment {
                         self.dirty = true;
                     }
                     let url = pr.url.clone();
+                    let is_mentioned = pr.role == PrRole::Mentioned;
                     if open::that(&url).is_err() {
                         self.status_message = Some(format!("Failed to open browser: {url}"));
+                        self.dirty = true;
+                    }
+                    if is_mentioned {
+                        // Mentioned PR は開いた時点で既読とみなしてリストから外し、
+                        // 永続 dismiss キューに積む。選択は同じ行位置の PR に再解決する。
+                        self.pending_dismissals.push(id.clone());
+                        self.prs.shift_remove(&id);
+                        if self.prs.is_empty() {
+                            self.list_state.select(None);
+                        } else {
+                            self.list_state.select(Some(i.min(self.prs.len() - 1)));
+                        }
                         self.dirty = true;
                     }
                 }
@@ -205,16 +223,26 @@ impl App {
                 let diff = diff_pr_sets(&self.prs, &incoming);
 
                 if already_loaded {
-                    // New PR added: only notify when we are NOT the author (review request)
+                    // New PR added: notify based on our role on it (author gets no notification)
                     for id in &diff.added {
-                        if let Some(pr) = incoming.get(id)
-                            && pr.role != PrRole::Author
-                            && self.notify_events.contains(&NotifyEvent::ReviewRequested)
-                        {
-                            self.pending_notifications.push(Notification {
-                                title: "Review requested".to_string(),
-                                body: format!("{} ({})", pr.title, id),
-                            });
+                        if let Some(pr) = incoming.get(id) {
+                            let notification = match pr.role {
+                                PrRole::ReviewRequested => {
+                                    Some(("Review requested", NotifyEvent::ReviewRequested))
+                                }
+                                PrRole::Mentioned => {
+                                    Some(("Mentioned in PR", NotifyEvent::Mentioned))
+                                }
+                                PrRole::Author => None,
+                            };
+                            if let Some((title, event)) = notification
+                                && self.notify_events.contains(&event)
+                            {
+                                self.pending_notifications.push(Notification {
+                                    title: title.to_string(),
+                                    body: format!("{} ({})", pr.title, id),
+                                });
+                            }
                         }
                     }
 
@@ -263,7 +291,7 @@ impl App {
                     for (id, new_pr) in &incoming {
                         if let Some(old_pr) = self.prs.get(id)
                             && new_pr.total_comments > old_pr.total_comments
-                            && matches!(new_pr.role, PrRole::Author | PrRole::Both)
+                            && new_pr.role == PrRole::Author
                             && new_pr.last_commenter.as_deref() != Some(self.username.as_str())
                         {
                             if self.notify_events.contains(&NotifyEvent::NewComment) {
@@ -279,7 +307,7 @@ impl App {
                     // CI status change: notify author when CI transitions from in-progress to finished
                     for (id, new_pr) in &incoming {
                         if let Some(old_pr) = self.prs.get(id)
-                            && matches!(new_pr.role, PrRole::Author | PrRole::Both)
+                            && new_pr.role == PrRole::Author
                             && old_pr
                                 .ci_status
                                 .as_ref()
@@ -1300,7 +1328,7 @@ mod tests {
     }
 
     #[test]
-    fn comment_increase_on_both_role_pr_triggers_notification() {
+    fn comment_increase_on_mentioned_role_pr_no_notification() {
         let mut app = App::new(
             "testuser".to_string(),
             ColorScheme::default(),
@@ -1310,19 +1338,127 @@ mod tests {
         let mut prs = IndexMap::new();
         prs.insert(
             id.clone(),
-            make_pr_with_comments(&id, PrRole::Both, None, 0, 0),
+            make_pr_with_comments(&id, PrRole::Mentioned, None, 0, 0),
         );
         app.update(Message::PollResult(payload_from(prs)));
 
         let mut prs2 = IndexMap::new();
         prs2.insert(
             id.clone(),
-            make_pr_with_comments(&id, PrRole::Both, None, 100, 2),
+            make_pr_with_comments(&id, PrRole::Mentioned, None, 100, 2),
         );
         app.update(Message::PollResult(payload_from(prs2)));
 
+        assert!(
+            app.pending_notifications.is_empty(),
+            "comment notification is author-only"
+        );
+    }
+
+    // --- Mentioned role ---
+
+    #[test]
+    fn added_mentioned_pr_triggers_mentioned_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        app.update(Message::PollResult(payload_from(IndexMap::new())));
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Mentioned, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
         assert_eq!(app.pending_notifications.len(), 1);
-        assert_eq!(app.pending_notifications[0].title, "New comment");
+        assert_eq!(app.pending_notifications[0].title, "Mentioned in PR");
+    }
+
+    #[test]
+    fn disabled_mentioned_suppresses_notification() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            events_except(NotifyEvent::Mentioned),
+        );
+        app.update(Message::PollResult(payload_from(IndexMap::new())));
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Mentioned, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
+        assert!(app.pending_notifications.is_empty());
+    }
+
+    #[test]
+    fn open_selected_mentioned_pr_queues_dismissal_and_removes_from_list() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id_mentioned = make_id(1);
+        let id_author = make_id(2);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id_mentioned.clone(),
+            make_pr_custom(&id_mentioned, PrRole::Mentioned, None, 0),
+        );
+        prs.insert(
+            id_author.clone(),
+            make_pr_custom(&id_author, PrRole::Author, None, 0),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+        app.update(Message::MoveDown); // select index 0 (mentioned)
+
+        app.update(Message::OpenSelected);
+
+        assert_eq!(app.pending_dismissals, vec![id_mentioned.clone()]);
+        assert!(!app.prs.contains_key(&id_mentioned));
+        // 選択は同じ行位置の残り PR に再解決される
+        assert_eq!(app.list_state.selected(), Some(0));
+        assert!(app.prs.contains_key(&id_author));
+        assert!(app.dirty);
+    }
+
+    #[test]
+    fn open_selected_last_mentioned_pr_clears_selection() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(id.clone(), make_pr_custom(&id, PrRole::Mentioned, None, 0));
+        app.update(Message::PollResult(payload_from(prs)));
+        app.update(Message::MoveDown);
+
+        app.update(Message::OpenSelected);
+
+        assert_eq!(app.pending_dismissals, vec![id]);
+        assert!(app.prs.is_empty());
+        assert_eq!(app.list_state.selected(), None);
+    }
+
+    #[test]
+    fn open_selected_non_mentioned_pr_does_not_queue_dismissal() {
+        let mut app = App::new(
+            "testuser".to_string(),
+            ColorScheme::default(),
+            NotifyEvent::all(),
+        );
+        let id = make_id(1);
+        let mut prs = IndexMap::new();
+        prs.insert(
+            id.clone(),
+            make_pr_custom(&id, PrRole::ReviewRequested, None, 0),
+        );
+        app.update(Message::PollResult(payload_from(prs)));
+        app.update(Message::MoveDown);
+
+        app.update(Message::OpenSelected);
+
+        assert!(app.pending_dismissals.is_empty());
+        assert!(app.prs.contains_key(&id));
     }
 
     #[test]
@@ -1795,7 +1931,7 @@ mod tests {
     }
 
     #[test]
-    fn ci_notification_for_both_role() {
+    fn ci_notification_not_for_mentioned_role() {
         let mut app = App::new(
             "testuser".to_string(),
             ColorScheme::default(),
@@ -1805,19 +1941,21 @@ mod tests {
         let mut prs = IndexMap::new();
         prs.insert(
             id.clone(),
-            make_pr_with_ci(&id, PrRole::Both, 0, Some(CiStatus::Pending)),
+            make_pr_with_ci(&id, PrRole::Mentioned, 0, Some(CiStatus::Pending)),
         );
         app.update(Message::PollResult(payload_from(prs)));
 
         let mut prs2 = IndexMap::new();
         prs2.insert(
             id.clone(),
-            make_pr_with_ci(&id, PrRole::Both, 100, Some(CiStatus::Failure)),
+            make_pr_with_ci(&id, PrRole::Mentioned, 100, Some(CiStatus::Failure)),
         );
         app.update(Message::PollResult(payload_from(prs2)));
 
-        assert_eq!(app.pending_notifications.len(), 1);
-        assert_eq!(app.pending_notifications[0].title, "CI failed");
+        assert!(
+            app.pending_notifications.is_empty(),
+            "CI notification is author-only"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::error::AppError;
 #[serde(rename_all = "snake_case")]
 pub enum NotifyEvent {
     ReviewRequested,
+    Mentioned,
     PrClosed,
     PrMerged,
     ReReviewRequested,
@@ -24,6 +25,7 @@ impl NotifyEvent {
     pub fn all() -> HashSet<NotifyEvent> {
         HashSet::from([
             NotifyEvent::ReviewRequested,
+            NotifyEvent::Mentioned,
             NotifyEvent::PrClosed,
             NotifyEvent::PrMerged,
             NotifyEvent::ReReviewRequested,
@@ -39,6 +41,7 @@ impl NotifyEvent {
     pub fn defaults() -> HashSet<NotifyEvent> {
         HashSet::from([
             NotifyEvent::ReviewRequested,
+            NotifyEvent::Mentioned,
             NotifyEvent::PrClosed,
             NotifyEvent::PrMerged,
             NotifyEvent::ReReviewRequested,
@@ -64,6 +67,7 @@ struct Cli {
 struct NotifyFileConfig {
     enabled: Option<bool>,
     review_requested: Option<bool>,
+    mentioned: Option<bool>,
     pr_closed: Option<bool>,
     pr_merged: Option<bool>,
     re_review_requested: Option<bool>,
@@ -112,6 +116,9 @@ fn resolve_notify_events(notify: &NotifyFileConfig) -> HashSet<NotifyEvent> {
     if notify.review_requested.unwrap_or(true) {
         events.insert(NotifyEvent::ReviewRequested);
     }
+    if notify.mentioned.unwrap_or(true) {
+        events.insert(NotifyEvent::Mentioned);
+    }
     if notify.pr_closed.unwrap_or(true) {
         events.insert(NotifyEvent::PrClosed);
     }
@@ -132,155 +139,6 @@ fn resolve_notify_events(notify: &NotifyFileConfig) -> HashSet<NotifyEvent> {
 
 fn config_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("prtop").join("config.toml"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn poll_interval_file_wins_when_cli_not_specified() {
-        assert_eq!(resolve_poll_interval(None, Some(30)), 30);
-    }
-
-    #[test]
-    fn poll_interval_cli_wins_over_file() {
-        assert_eq!(resolve_poll_interval(Some(120), Some(30)), 120);
-    }
-
-    #[test]
-    fn poll_interval_defaults_to_60() {
-        assert_eq!(resolve_poll_interval(None, None), 60);
-    }
-
-    // --- NotifyEvent ---
-
-    #[test]
-    fn notify_event_all_contains_every_variant() {
-        let all = NotifyEvent::all();
-        assert_eq!(all.len(), 6);
-        assert!(all.contains(&NotifyEvent::ReviewRequested));
-        assert!(all.contains(&NotifyEvent::PrClosed));
-        assert!(all.contains(&NotifyEvent::PrMerged));
-        assert!(all.contains(&NotifyEvent::ReReviewRequested));
-        assert!(all.contains(&NotifyEvent::NewComment));
-        assert!(all.contains(&NotifyEvent::CiFinished));
-    }
-
-    #[test]
-    fn notify_event_deserialize_snake_case() {
-        let cases = [
-            ("\"review_requested\"", NotifyEvent::ReviewRequested),
-            ("\"pr_closed\"", NotifyEvent::PrClosed),
-            ("\"pr_merged\"", NotifyEvent::PrMerged),
-            ("\"re_review_requested\"", NotifyEvent::ReReviewRequested),
-            ("\"new_comment\"", NotifyEvent::NewComment),
-            ("\"ci_finished\"", NotifyEvent::CiFinished),
-        ];
-        for (json, expected) in cases {
-            let parsed: NotifyEvent = serde_json::from_str(json).unwrap();
-            assert_eq!(parsed, expected);
-        }
-    }
-
-    #[test]
-    fn notify_event_deserialize_unknown_fails() {
-        let result: Result<NotifyEvent, _> = serde_json::from_str("\"unknown_event\"");
-        assert!(result.is_err());
-    }
-
-    // --- resolve_notify_events ---
-
-    #[test]
-    fn resolve_all_none_returns_defaults() {
-        let events = resolve_notify_events(&NotifyFileConfig::default());
-        assert_eq!(events, NotifyEvent::defaults());
-        assert!(!events.contains(&NotifyEvent::CiFinished));
-    }
-
-    #[test]
-    fn defaults_excludes_ci_finished() {
-        let defaults = NotifyEvent::defaults();
-        assert_eq!(defaults.len(), 5);
-        assert!(defaults.contains(&NotifyEvent::ReviewRequested));
-        assert!(defaults.contains(&NotifyEvent::PrClosed));
-        assert!(defaults.contains(&NotifyEvent::PrMerged));
-        assert!(defaults.contains(&NotifyEvent::ReReviewRequested));
-        assert!(defaults.contains(&NotifyEvent::NewComment));
-        assert!(!defaults.contains(&NotifyEvent::CiFinished));
-    }
-
-    #[test]
-    fn ci_finished_true_enables_it() {
-        let cfg = NotifyFileConfig {
-            ci_finished: Some(true),
-            ..Default::default()
-        };
-        let events = resolve_notify_events(&cfg);
-        assert!(events.contains(&NotifyEvent::CiFinished));
-        // Other defaults still on.
-        assert!(events.contains(&NotifyEvent::ReviewRequested));
-    }
-
-    #[test]
-    fn individual_false_disables_specific_event() {
-        let cfg = NotifyFileConfig {
-            new_comment: Some(false),
-            pr_merged: Some(false),
-            ..Default::default()
-        };
-        let events = resolve_notify_events(&cfg);
-        assert!(!events.contains(&NotifyEvent::NewComment));
-        assert!(!events.contains(&NotifyEvent::PrMerged));
-        assert!(events.contains(&NotifyEvent::ReviewRequested));
-        assert!(events.contains(&NotifyEvent::PrClosed));
-        assert!(events.contains(&NotifyEvent::ReReviewRequested));
-    }
-
-    #[test]
-    fn all_false_returns_empty() {
-        let cfg = NotifyFileConfig {
-            review_requested: Some(false),
-            pr_closed: Some(false),
-            pr_merged: Some(false),
-            re_review_requested: Some(false),
-            new_comment: Some(false),
-            ci_finished: Some(false),
-            ..Default::default()
-        };
-        assert!(resolve_notify_events(&cfg).is_empty());
-    }
-
-    // --- TOML deserialization ---
-
-    #[test]
-    fn toml_notify_with_individual_toggles() {
-        let toml_str = r#"
-            enabled = true
-            new_comment = false
-            ci_finished = true
-        "#;
-        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(parsed.enabled, Some(true));
-        assert_eq!(parsed.new_comment, Some(false));
-        assert_eq!(parsed.ci_finished, Some(true));
-        assert!(parsed.review_requested.is_none());
-
-        let events = resolve_notify_events(&parsed);
-        assert!(events.contains(&NotifyEvent::CiFinished));
-        assert!(!events.contains(&NotifyEvent::NewComment));
-        assert!(events.contains(&NotifyEvent::ReviewRequested));
-    }
-
-    #[test]
-    fn toml_notify_enabled_only_matches_defaults() {
-        let toml_str = r#"
-            enabled = true
-        "#;
-        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(parsed.enabled, Some(true));
-        assert_eq!(resolve_notify_events(&parsed), NotifyEvent::defaults());
-    }
 }
 
 fn load_file_config() -> FileConfig {
@@ -369,5 +227,158 @@ impl Config {
             notify_events,
             color_scheme,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_interval_file_wins_when_cli_not_specified() {
+        assert_eq!(resolve_poll_interval(None, Some(30)), 30);
+    }
+
+    #[test]
+    fn poll_interval_cli_wins_over_file() {
+        assert_eq!(resolve_poll_interval(Some(120), Some(30)), 120);
+    }
+
+    #[test]
+    fn poll_interval_defaults_to_60() {
+        assert_eq!(resolve_poll_interval(None, None), 60);
+    }
+
+    // --- NotifyEvent ---
+
+    #[test]
+    fn notify_event_all_contains_every_variant() {
+        let all = NotifyEvent::all();
+        assert_eq!(all.len(), 7);
+        assert!(all.contains(&NotifyEvent::ReviewRequested));
+        assert!(all.contains(&NotifyEvent::Mentioned));
+        assert!(all.contains(&NotifyEvent::PrClosed));
+        assert!(all.contains(&NotifyEvent::PrMerged));
+        assert!(all.contains(&NotifyEvent::ReReviewRequested));
+        assert!(all.contains(&NotifyEvent::NewComment));
+        assert!(all.contains(&NotifyEvent::CiFinished));
+    }
+
+    #[test]
+    fn notify_event_deserialize_snake_case() {
+        let cases = [
+            ("\"review_requested\"", NotifyEvent::ReviewRequested),
+            ("\"mentioned\"", NotifyEvent::Mentioned),
+            ("\"pr_closed\"", NotifyEvent::PrClosed),
+            ("\"pr_merged\"", NotifyEvent::PrMerged),
+            ("\"re_review_requested\"", NotifyEvent::ReReviewRequested),
+            ("\"new_comment\"", NotifyEvent::NewComment),
+            ("\"ci_finished\"", NotifyEvent::CiFinished),
+        ];
+        for (json, expected) in cases {
+            let parsed: NotifyEvent = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
+
+    #[test]
+    fn notify_event_deserialize_unknown_fails() {
+        let result: Result<NotifyEvent, _> = serde_json::from_str("\"unknown_event\"");
+        assert!(result.is_err());
+    }
+
+    // --- resolve_notify_events ---
+
+    #[test]
+    fn resolve_all_none_returns_defaults() {
+        let events = resolve_notify_events(&NotifyFileConfig::default());
+        assert_eq!(events, NotifyEvent::defaults());
+        assert!(!events.contains(&NotifyEvent::CiFinished));
+    }
+
+    #[test]
+    fn defaults_excludes_ci_finished() {
+        let defaults = NotifyEvent::defaults();
+        assert_eq!(defaults.len(), 6);
+        assert!(defaults.contains(&NotifyEvent::ReviewRequested));
+        assert!(defaults.contains(&NotifyEvent::Mentioned));
+        assert!(defaults.contains(&NotifyEvent::PrClosed));
+        assert!(defaults.contains(&NotifyEvent::PrMerged));
+        assert!(defaults.contains(&NotifyEvent::ReReviewRequested));
+        assert!(defaults.contains(&NotifyEvent::NewComment));
+        assert!(!defaults.contains(&NotifyEvent::CiFinished));
+    }
+
+    #[test]
+    fn ci_finished_true_enables_it() {
+        let cfg = NotifyFileConfig {
+            ci_finished: Some(true),
+            ..Default::default()
+        };
+        let events = resolve_notify_events(&cfg);
+        assert!(events.contains(&NotifyEvent::CiFinished));
+        // Other defaults still on.
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
+    }
+
+    #[test]
+    fn individual_false_disables_specific_event() {
+        let cfg = NotifyFileConfig {
+            new_comment: Some(false),
+            pr_merged: Some(false),
+            ..Default::default()
+        };
+        let events = resolve_notify_events(&cfg);
+        assert!(!events.contains(&NotifyEvent::NewComment));
+        assert!(!events.contains(&NotifyEvent::PrMerged));
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
+        assert!(events.contains(&NotifyEvent::PrClosed));
+        assert!(events.contains(&NotifyEvent::ReReviewRequested));
+    }
+
+    #[test]
+    fn all_false_returns_empty() {
+        let cfg = NotifyFileConfig {
+            review_requested: Some(false),
+            mentioned: Some(false),
+            pr_closed: Some(false),
+            pr_merged: Some(false),
+            re_review_requested: Some(false),
+            new_comment: Some(false),
+            ci_finished: Some(false),
+            ..Default::default()
+        };
+        assert!(resolve_notify_events(&cfg).is_empty());
+    }
+
+    // --- TOML deserialization ---
+
+    #[test]
+    fn toml_notify_with_individual_toggles() {
+        let toml_str = r#"
+            enabled = true
+            new_comment = false
+            ci_finished = true
+        "#;
+        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.enabled, Some(true));
+        assert_eq!(parsed.new_comment, Some(false));
+        assert_eq!(parsed.ci_finished, Some(true));
+        assert!(parsed.review_requested.is_none());
+
+        let events = resolve_notify_events(&parsed);
+        assert!(events.contains(&NotifyEvent::CiFinished));
+        assert!(!events.contains(&NotifyEvent::NewComment));
+        assert!(events.contains(&NotifyEvent::ReviewRequested));
+    }
+
+    #[test]
+    fn toml_notify_enabled_only_matches_defaults() {
+        let toml_str = r#"
+            enabled = true
+        "#;
+        let parsed: NotifyFileConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.enabled, Some(true));
+        assert_eq!(resolve_notify_events(&parsed), NotifyEvent::defaults());
     }
 }

--- a/src/dismiss.rs
+++ b/src/dismiss.rs
@@ -1,0 +1,322 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+
+use crate::error::AppError;
+use crate::types::PrId;
+
+/// Mentioned ロールの PR を「ブラウザで開いた」時点で非表示にするための永続ストア。
+/// `dismissed.json` は `{"owner/repo#123": "<dismiss 時刻 RFC3339>"}` の形式で、
+/// dismiss 後に他人から再メンションされた PR だけをリストに復帰させる判定に使う。
+#[derive(Debug)]
+pub struct DismissStore {
+    path: PathBuf,
+    map: HashMap<PrId, DateTime<Utc>>,
+    dirty: bool,
+}
+
+impl DismissStore {
+    pub fn load() -> Result<Self, AppError> {
+        let cache_dir = dirs::cache_dir().ok_or_else(|| {
+            AppError::Config(
+                "Cache directory not found (dismissed mentions cannot be persisted)".to_string(),
+            )
+        })?;
+        Self::load_from(cache_dir.join("prtop").join("dismissed.json"))
+    }
+
+    /// パスを指定してロードする。ファイルが無ければ空(初回起動)。
+    /// パース失敗は silent fallback せず fail fast する。
+    pub fn load_from(path: PathBuf) -> Result<Self, AppError> {
+        let map = match std::fs::read_to_string(&path) {
+            Ok(text) => parse_store(&text).map_err(|e| {
+                AppError::Config(format!(
+                    "Failed to parse {}: {e}. Delete the file to recover (dismissed mentions will reappear).",
+                    path.display()
+                ))
+            })?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) => return Err(AppError::Io(e)),
+        };
+        Ok(Self {
+            path,
+            map,
+            dirty: false,
+        })
+    }
+
+    /// 親ディレクトリを作成し、テンポラリファイル経由で atomic に書き込む。
+    pub fn save(&mut self) -> Result<(), AppError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut json = serde_json::Map::new();
+        for (id, at) in &self.map {
+            json.insert(id.to_string(), serde_json::Value::String(at.to_rfc3339()));
+        }
+        let text = serde_json::to_string_pretty(&serde_json::Value::Object(json))
+            .map_err(|e| AppError::Config(format!("Failed to serialize dismiss store: {e}")))?;
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, text)?;
+        std::fs::rename(&tmp, &self.path)?;
+        self.dirty = false;
+        Ok(())
+    }
+
+    pub fn dismiss(&mut self, id: PrId, at: DateTime<Utc>) {
+        self.map.insert(id, at);
+        self.dirty = true;
+    }
+
+    pub fn undismiss(&mut self, id: &PrId) {
+        if self.map.remove(id).is_some() {
+            self.dirty = true;
+        }
+    }
+
+    /// テスト用途が主(poller は snapshot() 経由で参照する)。
+    #[allow(dead_code)]
+    pub fn get(&self, id: &PrId) -> Option<DateTime<Utc>> {
+        self.map.get(id).copied()
+    }
+
+    /// mentions クエリ結果に存在しなくなった PR のエントリを掃除する。
+    pub fn retain_ids(&mut self, keep: &HashSet<PrId>) {
+        let before = self.map.len();
+        self.map.retain(|id, _| keep.contains(id));
+        if self.map.len() != before {
+            self.dirty = true;
+        }
+    }
+
+    pub fn snapshot(&self) -> HashMap<PrId, DateTime<Utc>> {
+        self.map.clone()
+    }
+
+    pub fn dismissed_ids(&self) -> HashSet<PrId> {
+        self.map.keys().cloned().collect()
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+}
+
+fn parse_store(text: &str) -> Result<HashMap<PrId, DateTime<Utc>>, String> {
+    let raw: HashMap<String, DateTime<Utc>> =
+        serde_json::from_str(text).map_err(|e| e.to_string())?;
+    let mut map = HashMap::with_capacity(raw.len());
+    for (key, at) in raw {
+        map.insert(parse_pr_id(&key)?, at);
+    }
+    Ok(map)
+}
+
+/// `owner/repo#123` (PrId の Display 形式) をパースする。不正キーはエラー。
+fn parse_pr_id(key: &str) -> Result<PrId, String> {
+    let (repo_part, number) = key
+        .rsplit_once('#')
+        .ok_or_else(|| format!("invalid PR key (missing '#'): {key:?}"))?;
+    let number: u64 = number
+        .parse()
+        .map_err(|_| format!("invalid PR number in key: {key:?}"))?;
+    let (owner, repo) = repo_part
+        .split_once('/')
+        .ok_or_else(|| format!("invalid PR key (missing '/'): {key:?}"))?;
+    if owner.is_empty() || repo.is_empty() {
+        return Err(format!("invalid PR key (empty owner or repo): {key:?}"));
+    }
+    Ok(PrId {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        number,
+    })
+}
+
+/// コメント本文に `@username` メンションが含まれるかを判定する(ASCII case-insensitive)。
+/// GitHub の login は `[A-Za-z0-9-]` なので、直前が英数字/`-`/`@` でなく、
+/// 直後が英数字/`-` でない位置だけをメンション境界とみなす。
+pub fn contains_mention(body: &str, username: &str) -> bool {
+    if username.is_empty() {
+        return false;
+    }
+    let bytes = body.as_bytes();
+    let uname = username.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'@' {
+            continue;
+        }
+        let prev_ok = i == 0 || {
+            let p = bytes[i - 1];
+            !(p.is_ascii_alphanumeric() || p == b'-' || p == b'@')
+        };
+        if !prev_ok {
+            continue;
+        }
+        let start = i + 1;
+        let end = start + uname.len();
+        if end > bytes.len() || !bytes[start..end].eq_ignore_ascii_case(uname) {
+            continue;
+        }
+        let next_ok = end == bytes.len() || {
+            let n = bytes[end];
+            !(n.is_ascii_alphanumeric() || n == b'-')
+        };
+        if next_ok {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "prtop-dismiss-test-{name}-{}-{}.json",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ))
+    }
+
+    fn make_id(number: u64) -> PrId {
+        PrId {
+            owner: "org".to_string(),
+            repo: "repo".to_string(),
+            number,
+        }
+    }
+
+    // --- load / save ---
+
+    #[test]
+    fn load_missing_file_gives_empty_store() {
+        let store = DismissStore::load_from(temp_store_path("missing")).unwrap();
+        assert!(store.snapshot().is_empty());
+        assert!(!store.is_dirty());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let path = temp_store_path("roundtrip");
+        let mut store = DismissStore::load_from(path.clone()).unwrap();
+        let at = "2026-07-18T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        store.dismiss(make_id(1), at);
+        assert!(store.is_dirty());
+        store.save().unwrap();
+        assert!(!store.is_dirty());
+
+        let reloaded = DismissStore::load_from(path.clone()).unwrap();
+        assert_eq!(reloaded.get(&make_id(1)), Some(at));
+        assert_eq!(reloaded.snapshot().len(), 1);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn load_corrupt_json_fails_with_path_in_message() {
+        let path = temp_store_path("corrupt");
+        std::fs::write(&path, "not json").unwrap();
+        let err = DismissStore::load_from(path.clone()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&path.display().to_string()), "message: {msg}");
+        assert!(msg.contains("Delete the file"), "message: {msg}");
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn load_invalid_key_fails() {
+        let path = temp_store_path("badkey");
+        std::fs::write(&path, r#"{"no-hash-here": "2026-07-18T00:00:00Z"}"#).unwrap();
+        assert!(DismissStore::load_from(path.clone()).is_err());
+        std::fs::remove_file(path).unwrap();
+    }
+
+    // --- parse_pr_id ---
+
+    #[test]
+    fn parse_pr_id_display_roundtrip() {
+        let id = make_id(42);
+        assert_eq!(parse_pr_id(&id.to_string()).unwrap(), id);
+    }
+
+    #[test]
+    fn parse_pr_id_rejects_malformed_keys() {
+        assert!(parse_pr_id("org/repo").is_err());
+        assert!(parse_pr_id("orgrepo#1").is_err());
+        assert!(parse_pr_id("org/repo#abc").is_err());
+        assert!(parse_pr_id("/repo#1").is_err());
+        assert!(parse_pr_id("org/#1").is_err());
+    }
+
+    // --- mutation API ---
+
+    #[test]
+    fn undismiss_removes_entry_and_marks_dirty() {
+        let mut store = DismissStore::load_from(temp_store_path("undismiss")).unwrap();
+        store.dismiss(make_id(1), Utc::now());
+        store.undismiss(&make_id(1));
+        assert_eq!(store.get(&make_id(1)), None);
+        assert!(store.is_dirty());
+    }
+
+    #[test]
+    fn undismiss_unknown_id_does_not_mark_dirty() {
+        let mut store = DismissStore::load_from(temp_store_path("undismiss-noop")).unwrap();
+        store.undismiss(&make_id(1));
+        assert!(!store.is_dirty());
+    }
+
+    #[test]
+    fn retain_ids_drops_entries_not_in_keep_set() {
+        let mut store = DismissStore::load_from(temp_store_path("retain")).unwrap();
+        store.dismiss(make_id(1), Utc::now());
+        store.dismiss(make_id(2), Utc::now());
+        let keep = HashSet::from([make_id(1)]);
+        store.retain_ids(&keep);
+        assert!(store.get(&make_id(1)).is_some());
+        assert_eq!(store.get(&make_id(2)), None);
+    }
+
+    // --- contains_mention ---
+
+    #[test]
+    fn mention_simple_hit() {
+        assert!(contains_mention("hey @user please look", "user"));
+        assert!(contains_mention("@user", "user"));
+        assert!(contains_mention("cc: @user.", "user"));
+    }
+
+    #[test]
+    fn mention_is_ascii_case_insensitive() {
+        assert!(contains_mention("(@User)", "user"));
+        assert!(contains_mention("@USER!", "user"));
+        assert!(contains_mention("@user", "USER"));
+    }
+
+    #[test]
+    fn mention_longer_login_does_not_hit() {
+        assert!(!contains_mention("ping @username2", "username"));
+        assert!(!contains_mention("ping @user-name", "user"));
+    }
+
+    #[test]
+    fn mention_requires_boundary_before_at() {
+        assert!(!contains_mention("foo@user", "user"));
+        assert!(!contains_mention("a-@user", "user"));
+        assert!(!contains_mention("@@user", "user"));
+        assert!(contains_mention("(@user)", "user"));
+        assert!(contains_mention("日本語で@userに依頼", "user"));
+    }
+
+    #[test]
+    fn mention_no_hit_cases() {
+        assert!(!contains_mention("", "user"));
+        assert!(!contains_mention("user without at", "user"));
+        assert!(!contains_mention("@", "user"));
+        assert!(!contains_mention("@other", "user"));
+        assert!(!contains_mention("@user", ""));
+    }
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1,10 +1,15 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde_json::json;
 
 use crate::error::AppError;
-use crate::github::query::SEARCH_PRS_QUERY;
-use crate::github::types::{CheckRunsResponse, CombinedStatusResponse, GraphQlResponse, PrNode};
-use crate::types::CiStatus;
+use crate::github::query::{self, SEARCH_PRS_QUERY};
+use crate::github::types::{
+    CheckRunsResponse, CombinedStatusResponse, GraphQlResponse, PrNode, RecentComment,
+};
+use crate::types::{CiStatus, PrId};
 
 const GITHUB_API_BASE: &str = "https://api.github.com";
 const PAGE_SIZE: u64 = 50;
@@ -70,38 +75,7 @@ impl GitHubClient {
                 .send()
                 .await?;
 
-            let status = response.status();
-
-            if status == reqwest::StatusCode::UNAUTHORIZED
-                || status == reqwest::StatusCode::FORBIDDEN
-            {
-                let retry_after = response
-                    .headers()
-                    .get("retry-after")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok());
-
-                let rate_remaining = response
-                    .headers()
-                    .get("x-ratelimit-remaining")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.parse::<u64>().ok());
-
-                if rate_remaining == Some(0) || retry_after.is_some() {
-                    return Err(AppError::RateLimited {
-                        retry_after_secs: retry_after.unwrap_or(60),
-                    });
-                }
-
-                let text = response.text().await.unwrap_or_default();
-                return Err(AppError::Auth(format!("{status}: {text}")));
-            }
-
-            if !status.is_success() {
-                let text = response.text().await.unwrap_or_default();
-                return Err(AppError::GraphQl(format!("{status}: {text}")));
-            }
-
+            let response = ensure_graphql_http_success(response).await?;
             let gql_response: GraphQlResponse = response.json().await?;
 
             if let Some(errors) = gql_response.errors {
@@ -123,6 +97,87 @@ impl GitHubClient {
         }
 
         Ok(all_nodes)
+    }
+
+    /// dismiss 済み mentioned PR の直近 issue コメントを一括取得する。
+    /// エイリアス付きの単一 GraphQL クエリで全 PR 分をまとめて引き、
+    /// エイリアスキーが動的なためレスポンスは serde_json::Value で手動パースする。
+    /// レビューコメント(コードコメント)内の再メンション検出は v1 スコープ外。
+    pub async fn fetch_recent_comments(
+        &self,
+        prs: &[PrId],
+    ) -> Result<HashMap<PrId, Vec<RecentComment>>, AppError> {
+        if prs.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let url = format!("{}/graphql", self.api_base);
+        let body = json!({ "query": query::recent_comments_query(prs) });
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await?;
+
+        let response = ensure_graphql_http_success(response).await?;
+        let value: serde_json::Value = response.json().await?;
+
+        if let Some(errors) = value.get("errors").and_then(|e| e.as_array()) {
+            let msgs: Vec<String> = errors
+                .iter()
+                .map(|e| {
+                    e.get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown error")
+                        .to_string()
+                })
+                .collect();
+            return Err(AppError::GraphQl(msgs.join("; ")));
+        }
+
+        let data = value
+            .get("data")
+            .ok_or_else(|| AppError::GraphQl("No data in response".to_string()))?;
+
+        let mut result = HashMap::with_capacity(prs.len());
+        for (i, id) in prs.iter().enumerate() {
+            let nodes = data
+                .get(format!("pr{i}"))
+                .and_then(|r| r.get("pullRequest"))
+                .and_then(|p| p.get("comments"))
+                .and_then(|c| c.get("nodes"))
+                .and_then(|n| n.as_array());
+            let mut comments = Vec::new();
+            if let Some(nodes) = nodes {
+                for node in nodes {
+                    let body_text = node
+                        .get("bodyText")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let created_at = node
+                        .get("createdAt")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+                        .unwrap_or_default();
+                    let author_login = node
+                        .get("author")
+                        .and_then(|a| a.get("login"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string);
+                    comments.push(RecentComment {
+                        body_text,
+                        created_at,
+                        author_login,
+                    });
+                }
+            }
+            result.insert(id.clone(), comments);
+        }
+        Ok(result)
     }
 
     /// Fetch the CI status for a commit by combining the legacy commit-status API
@@ -205,6 +260,44 @@ impl GitHubClient {
         }
         Ok(Some(response.json().await?))
     }
+}
+
+/// GraphQL エンドポイントの HTTP レベルのエラー(401/403/rate limit/その他非2xx)を
+/// [`AppError`] に分類する。成功時はレスポンスをそのまま返す。
+async fn ensure_graphql_http_success(
+    response: reqwest::Response,
+) -> Result<reqwest::Response, AppError> {
+    let status = response.status();
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+
+        let rate_remaining = response
+            .headers()
+            .get("x-ratelimit-remaining")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+
+        if rate_remaining == Some(0) || retry_after.is_some() {
+            return Err(AppError::RateLimited {
+                retry_after_secs: retry_after.unwrap_or(60),
+            });
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        return Err(AppError::Auth(format!("{status}: {text}")));
+    }
+
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(AppError::GraphQl(format!("{status}: {text}")));
+    }
+
+    Ok(response)
 }
 
 fn compute_ci_status(

--- a/src/github/query.rs
+++ b/src/github/query.rs
@@ -58,3 +58,26 @@ pub fn review_requested_search_query(username: &str) -> String {
 pub fn review_requested_closed_search_query(username: &str) -> String {
     format!("is:pr -is:open review-requested:{username}")
 }
+
+pub fn mentions_search_query(username: &str) -> String {
+    format!("is:pr is:open mentions:{username}")
+}
+
+pub fn mentions_closed_search_query(username: &str) -> String {
+    format!("is:pr -is:open mentions:{username}")
+}
+
+/// dismiss 済み mentioned PR の直近コメントを一括取得するクエリを組み立てる。
+/// PR ごとに `pr{i}` エイリアスを振るため、レスポンスのキーは動的になる
+/// (パース側は serde ではなく serde_json::Value で処理する)。
+pub fn recent_comments_query(prs: &[crate::types::PrId]) -> String {
+    let mut q = String::from("query {");
+    for (i, id) in prs.iter().enumerate() {
+        q.push_str(&format!(
+            " pr{i}: repository(owner: \"{}\", name: \"{}\") {{ pullRequest(number: {}) {{ comments(last: 20) {{ nodes {{ bodyText createdAt author {{ login }} }} }} }} }}",
+            id.owner, id.repo, id.number
+        ));
+    }
+    q.push_str(" }");
+    q
+}

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +50,15 @@ pub struct CommentsConnection {
     pub total_count: u64,
     #[serde(default)]
     pub nodes: Vec<CommentNode>,
+}
+
+/// [`crate::github::client::GitHubClient::fetch_recent_comments`] が返す直近コメント。
+/// レスポンスはエイリアスキーが動的なため serde ではなく手動パースで組み立てる。
+#[derive(Debug, Clone)]
+pub struct RecentComment {
+    pub body_text: String,
+    pub created_at: DateTime<Utc>,
+    pub author_login: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod colors;
 pub mod config;
 pub mod diff;
+pub mod dismiss;
 pub mod error;
 pub mod github;
 pub mod notify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod colors;
 mod config;
 mod diff;
+mod dismiss;
 mod error;
 mod github;
 mod notify;
@@ -9,19 +10,24 @@ mod poller;
 mod tui;
 mod types;
 
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use app::{App, Message, Screen};
 use config::Config;
+use dismiss::DismissStore;
 use github::client::GitHubClient;
 use notify::build_notifier;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
+    // terminal init 前にロードして、壊れた dismissed.json は起動エラーとして表示する。
+    let dismiss_store = Arc::new(Mutex::new(DismissStore::load()?));
 
     let cancel = CancellationToken::new();
     let (msg_tx, mut msg_rx) = mpsc::channel::<Message>(64);
@@ -57,6 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let error_tx = msg_tx.clone();
     let username = config.username.clone();
     let interval = Duration::from_secs(config.poll_interval_secs);
+    let poll_dismiss_store = dismiss_store.clone();
 
     tokio::spawn(async move {
         let error_sender = {
@@ -83,9 +90,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         poller::polling_loop(
-            client,
-            username,
-            interval,
+            poller::PollerContext {
+                client,
+                username,
+                interval,
+                dismiss_store: poll_dismiss_store,
+            },
             poll_sender,
             error_sender,
             poll_cancel,
@@ -112,6 +122,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 for n in app.pending_notifications.drain(..) {
                     notifier.notify(&n);
+                }
+                if !app.pending_dismissals.is_empty() {
+                    let mut store = dismiss_store.lock().expect("dismiss store lock poisoned");
+                    let now = Utc::now();
+                    for id in app.pending_dismissals.drain(..) {
+                        store.dismiss(id, now);
+                    }
+                    if let Err(e) = store.save() {
+                        app.update(Message::PollError(format!(
+                            "Failed to save dismissed mentions: {e}"
+                        )));
+                    }
                 }
             }
             _ = tokio::time::sleep(Duration::from_millis(200)) => {

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -7,6 +8,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
+use crate::dismiss::{DismissStore, contains_mention};
 use crate::error::AppError;
 use crate::github::client::{GitHubClient, MAX_PAGES};
 use crate::github::query;
@@ -59,28 +61,41 @@ fn node_to_pr(node: PrNode, role: PrRole) -> (PullRequest, String) {
     (pr, head_sha)
 }
 
+fn node_id(node: &PrNode) -> PrId {
+    PrId {
+        owner: node.repository.owner.login.clone(),
+        repo: node.repository.name.clone(),
+        number: node.number,
+    }
+}
+
 pub fn merge_and_convert(
     author_nodes: Vec<PrNode>,
     review_nodes: Vec<PrNode>,
+    mentioned_nodes: Vec<PrNode>,
 ) -> (IndexMap<PrId, PullRequest>, HashMap<PrId, String>) {
-    let mut result = IndexMap::new();
+    let mut result: IndexMap<PrId, PullRequest> = IndexMap::new();
     let mut shas: HashMap<PrId, String> = HashMap::new();
 
-    let mut author_ids: HashSet<PrId> = HashSet::new();
+    // 同一 PR が複数クエリに現れた場合は Author > ReviewRequested > Mentioned の
+    // 優先度で解決する(先に insert された方が勝つ)。
     for node in author_nodes {
         let (pr, sha) = node_to_pr(node, PrRole::Author);
-        author_ids.insert(pr.id.clone());
         shas.insert(pr.id.clone(), sha);
         result.insert(pr.id.clone(), pr);
     }
 
     for node in review_nodes {
         let (pr, sha) = node_to_pr(node, PrRole::ReviewRequested);
-        if author_ids.contains(&pr.id) {
-            if let Some(existing) = result.get_mut(&pr.id) {
-                existing.role = PrRole::Both;
-            }
-        } else {
+        if !result.contains_key(&pr.id) {
+            shas.insert(pr.id.clone(), sha);
+            result.insert(pr.id.clone(), pr);
+        }
+    }
+
+    for node in mentioned_nodes {
+        let (pr, sha) = node_to_pr(node, PrRole::Mentioned);
+        if !result.contains_key(&pr.id) {
             shas.insert(pr.id.clone(), sha);
             result.insert(pr.id.clone(), pr);
         }
@@ -118,10 +133,16 @@ async fn enrich_with_ci_status(
     }
 }
 
+/// polling_loop の実行時依存(クライアント・対象ユーザー・ポーリング間隔・dismiss 状態)。
+pub struct PollerContext {
+    pub client: GitHubClient,
+    pub username: String,
+    pub interval: Duration,
+    pub dismiss_store: Arc<Mutex<DismissStore>>,
+}
+
 pub async fn polling_loop(
-    client: GitHubClient,
-    username: String,
-    interval: Duration,
+    ctx: PollerContext,
     tx: mpsc::Sender<PollPayload>,
     error_tx: mpsc::Sender<String>,
     cancel: CancellationToken,
@@ -130,7 +151,7 @@ pub async fn polling_loop(
     let mut backoff_secs = 0u64;
 
     loop {
-        let result = poll_once(&client, &username).await;
+        let result = poll_once(&ctx.client, &ctx.username, &ctx.dismiss_store, &error_tx).await;
 
         match result {
             Ok(payload) => {
@@ -168,27 +189,36 @@ pub async fn polling_loop(
 
         // Wait for next interval or manual refresh
         tokio::select! {
-            _ = tokio::time::sleep(interval) => {}
+            _ = tokio::time::sleep(ctx.interval) => {}
             _ = refresh_rx.recv() => {}
             _ = cancel.cancelled() => return,
         }
     }
 }
 
-async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload, AppError> {
+async fn poll_once(
+    client: &GitHubClient,
+    username: &str,
+    dismiss_store: &Mutex<DismissStore>,
+    error_tx: &mpsc::Sender<String>,
+) -> Result<PollPayload, AppError> {
     let author_open_query = query::author_search_query(username);
     let author_closed_query = query::author_closed_search_query(username);
     let review_open_query = query::review_requested_search_query(username);
     let review_closed_query = query::review_requested_closed_search_query(username);
+    let mentions_open_query = query::mentions_search_query(username);
+    let mentions_closed_query = query::mentions_closed_search_query(username);
 
-    // Run all four queries in parallel.
+    // Run all six queries in parallel.
     // Open queries are fully paginated to ensure no active PRs are missed.
     // Closed/merged queries fetch only one page (the most recently updated ones).
-    let (author_open, author_closed, review_open, review_closed) = tokio::join!(
+    let (author_open, author_closed, review_open, review_closed, mentions_open, mentions_closed) = tokio::join!(
         client.search_prs(&author_open_query, MAX_PAGES),
         client.search_prs(&author_closed_query, 1),
         client.search_prs(&review_open_query, MAX_PAGES),
         client.search_prs(&review_closed_query, 1),
+        client.search_prs(&mentions_open_query, MAX_PAGES),
+        client.search_prs(&mentions_closed_query, 1),
     );
 
     let mut author_nodes = author_open?;
@@ -197,7 +227,75 @@ async fn poll_once(client: &GitHubClient, username: &str) -> Result<PollPayload,
     let mut review_nodes = review_open?;
     review_nodes.extend(review_closed?);
 
-    let (mut prs, shas) = merge_and_convert(author_nodes, review_nodes);
+    let mut mentioned_nodes = mentions_open?;
+    mentioned_nodes.extend(mentions_closed?);
+
+    let mention_ids: HashSet<PrId> = mentioned_nodes.iter().map(node_id).collect();
+
+    let (mut prs, shas) = merge_and_convert(author_nodes, review_nodes, mentioned_nodes);
+
+    // mentions クエリに出なくなった PR の dismiss エントリは掃除する。
+    // 全クエリ成功後(`?` の後)なので、エラー時に誤って掃除されることはない。
+    // ロックは std::sync::Mutex のため await を跨がないよう、スナップショットを取ってすぐ手放す。
+    let dismissed = {
+        let mut store = dismiss_store.lock().expect("dismiss store lock poisoned");
+        store.retain_ids(&mention_ids);
+        store.snapshot()
+    };
+
+    // dismiss 後に更新があった mentioned PR だけ、直近 issue コメントを見て
+    // 再メンションを検証する(レビューコメント内の再メンション検出は v1 スコープ外)。
+    let candidates: Vec<(PrId, DateTime<Utc>)> = prs
+        .iter()
+        .filter(|(_, pr)| pr.role == PrRole::Mentioned)
+        .filter_map(|(id, pr)| {
+            let dismissed_at = *dismissed.get(id)?;
+            (pr.updated_at > dismissed_at).then(|| (id.clone(), dismissed_at))
+        })
+        .collect();
+
+    let mut undismissed: HashSet<PrId> = HashSet::new();
+    if !candidates.is_empty() {
+        let ids: Vec<PrId> = candidates.iter().map(|(id, _)| id.clone()).collect();
+        // 再メンション検証は best-effort: 失敗しても poll 全体は落とさず、
+        // 該当 PR はこのポーリングでは dismissed のまま維持する。
+        match client.fetch_recent_comments(&ids).await {
+            Ok(comments) => {
+                for (id, dismissed_at) in &candidates {
+                    let re_mentioned = comments.get(id).is_some_and(|list| {
+                        list.iter().any(|c| {
+                            c.created_at > *dismissed_at
+                                && !c
+                                    .author_login
+                                    .as_deref()
+                                    .is_some_and(|a| a.eq_ignore_ascii_case(username))
+                                && contains_mention(&c.body_text, username)
+                        })
+                    });
+                    if re_mentioned {
+                        undismissed.insert(id.clone());
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = error_tx.send(format!("Mention re-check failed: {e}")).await;
+            }
+        }
+    }
+
+    let still_dismissed = {
+        let mut store = dismiss_store.lock().expect("dismiss store lock poisoned");
+        for id in &undismissed {
+            store.undismiss(id);
+        }
+        if store.is_dirty() {
+            store.save()?;
+        }
+        store.dismissed_ids()
+    };
+
+    // dismiss されたままの Mentioned ロール PR はリストに出さない。
+    prs.retain(|id, pr| pr.role != PrRole::Mentioned || !still_dismissed.contains(id));
 
     enrich_with_ci_status(client, &mut prs, shas).await;
 
@@ -248,8 +346,7 @@ mod tests {
     #[test]
     fn merge_author_only() {
         let author = vec![make_node("org", "repo", 1)];
-        let review = vec![];
-        let (result, _) = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(author, vec![], vec![]);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
         assert_eq!(pr.role, PrRole::Author);
@@ -257,30 +354,50 @@ mod tests {
 
     #[test]
     fn merge_review_only() {
-        let author = vec![];
         let review = vec![make_node("org", "repo", 1)];
-        let (result, _) = merge_and_convert(author, review);
+        let (result, _) = merge_and_convert(vec![], review, vec![]);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
         assert_eq!(pr.role, PrRole::ReviewRequested);
     }
 
     #[test]
-    fn merge_both_roles() {
-        let author = vec![make_node("org", "repo", 1)];
-        let review = vec![make_node("org", "repo", 1)];
-        let (result, _) = merge_and_convert(author, review);
+    fn merge_mentioned_only() {
+        let mentioned = vec![make_node("org", "repo", 1)];
+        let (result, _) = merge_and_convert(vec![], vec![], mentioned);
         assert_eq!(result.len(), 1);
         let pr = result.values().next().unwrap();
-        assert_eq!(pr.role, PrRole::Both);
+        assert_eq!(pr.role, PrRole::Mentioned);
+    }
+
+    #[test]
+    fn merge_author_wins_over_review_and_mentioned() {
+        let author = vec![make_node("org", "repo", 1)];
+        let review = vec![make_node("org", "repo", 1)];
+        let mentioned = vec![make_node("org", "repo", 1)];
+        let (result, _) = merge_and_convert(author, review, mentioned);
+        assert_eq!(result.len(), 1);
+        let pr = result.values().next().unwrap();
+        assert_eq!(pr.role, PrRole::Author);
+    }
+
+    #[test]
+    fn merge_review_wins_over_mentioned() {
+        let review = vec![make_node("org", "repo", 1)];
+        let mentioned = vec![make_node("org", "repo", 1)];
+        let (result, _) = merge_and_convert(vec![], review, mentioned);
+        assert_eq!(result.len(), 1);
+        let pr = result.values().next().unwrap();
+        assert_eq!(pr.role, PrRole::ReviewRequested);
     }
 
     #[test]
     fn merge_distinct_prs() {
         let author = vec![make_node("org", "repo", 1)];
         let review = vec![make_node("org", "repo", 2)];
-        let (result, _) = merge_and_convert(author, review);
-        assert_eq!(result.len(), 2);
+        let mentioned = vec![make_node("org", "repo", 3)];
+        let (result, _) = merge_and_convert(author, review, mentioned);
+        assert_eq!(result.len(), 3);
     }
 
     // --- parse_state ---
@@ -389,6 +506,15 @@ mod tests {
         })
     }
 
+    fn test_dismiss_store(name: &str) -> Arc<Mutex<DismissStore>> {
+        let path = std::env::temp_dir().join(format!(
+            "prtop-poller-test-{name}-{}-{}.json",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        Arc::new(Mutex::new(DismissStore::load_from(path).unwrap()))
+    }
+
     #[tokio::test]
     async fn polling_loop_stops_on_cancel() {
         let server = MockServer::start().await;
@@ -406,9 +532,12 @@ mod tests {
 
         let handle = tokio::spawn(async move {
             polling_loop(
-                client,
-                "user".to_string(),
-                Duration::from_secs(3600),
+                PollerContext {
+                    client,
+                    username: "user".to_string(),
+                    interval: Duration::from_secs(3600),
+                    dismiss_store: test_dismiss_store("cancel"),
+                },
                 tx,
                 err_tx,
                 cancel_clone,
@@ -448,9 +577,12 @@ mod tests {
 
         let handle = tokio::spawn(async move {
             polling_loop(
-                client,
-                "user".to_string(),
-                Duration::from_secs(60),
+                PollerContext {
+                    client,
+                    username: "user".to_string(),
+                    interval: Duration::from_secs(60),
+                    dismiss_store: test_dismiss_store("auth"),
+                },
                 tx,
                 err_tx,
                 cancel_clone,
@@ -494,9 +626,12 @@ mod tests {
 
         let handle = tokio::spawn(async move {
             polling_loop(
-                client,
-                "user".to_string(),
-                Duration::from_secs(3600),
+                PollerContext {
+                    client,
+                    username: "user".to_string(),
+                    interval: Duration::from_secs(3600),
+                    dismiss_store: test_dismiss_store("refresh"),
+                },
                 tx,
                 err_tx,
                 cancel_clone,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -20,7 +20,7 @@ pub fn view(f: &mut Frame, app: &mut App) {
 /// Layout: [▸ ][role][  ][status][  ][ci][  ][number][title][  ][repo]
 fn col_widths(term_width: u16, app: &App) -> (usize, usize, usize, usize, usize, usize) {
     let effective = (term_width as usize).saturating_sub(2); // 2 for "▸ " / "  "
-    let role: usize = 6; // "AUTHOR", "REVIEW", "BOTH  "
+    let role: usize = 7; // "AUTHOR ", "REVIEW ", "MENTION"
     let status: usize = 6; // "OPEN  ", "CLOSED", "MERGED"
     let ci: usize = 3; // "✓  ", "×  ", "...", "-  "
     let number: usize = 7; // "#12345 "
@@ -176,7 +176,7 @@ fn render_list(
             let role_tag = match pr.role {
                 PrRole::Author => "AUTHOR",
                 PrRole::ReviewRequested => "REVIEW",
-                PrRole::Both => "BOTH",
+                PrRole::Mentioned => "MENTION",
             };
 
             let (status_tag, status_style) = match pr.state {

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for PrId {
 pub enum PrRole {
     Author,
     ReviewRequested,
-    Both,
+    Mentioned,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Closes #9

## What

PRs where you are `@mentioned` now appear in the list with a `MENTION` role tag and trigger a "Mentioned in PR" notification.

## Design (as agreed in #9)

- **Roles**: `PrRole::Both` is removed. `PrRole { Author, ReviewRequested, Mentioned }`, resolved by priority `Author > ReviewRequested > Mentioned` when the same PR appears in multiple queries.
- **Queries**: `mentions:{username}` open/closed added — six parallel GraphQL searches in `poll_once()`.
- **Dismiss on open**: opening a Mentioned PR in the browser (`OpenSelected`) removes it from the list. Dismissals persist in `<cache_dir>/prtop/dismissed.json` (`{"owner/repo#N": "<RFC3339 dismissed_at>"}`), written atomically (tmp + rename), parsed fail-fast with a recovery hint.
- **Re-display (precise + cheap)**: instead of the `total_comments` counter from the issue notes, dismiss stores a timestamp. On each poll, only dismissed PRs with `updatedAt > dismissed_at` trigger a single alias-batched GraphQL query fetching the last 20 issue comments; the PR reappears (with a notification) only when someone else `@mentions` you after `dismissed_at`. Verification failures are best-effort and never fail the poll. Rationale: `comments.totalCount` excludes review comments and decreases on deletion, so the counter approach both misses re-mentions and can get stuck.
- **Cleanup**: dismiss entries for PRs no longer in the `mentions:` results are pruned, only after all queries succeed (an API error can never wipe state).
- **Notification**: new `NotifyEvent::Mentioned` toggle (`mentioned = true` by default). Added-PR notifications are now role-branched — previously `role != Author` implied "Review requested", which would have misfired for mentioned PRs.

## Also in this PR

- Comment/CI notification filters normalized from `Author | Both` to `Author` (fallout of `Both` removal)
- `polling_loop` deps grouped into `PollerContext` (clippy `too_many_arguments`)
- `config.rs` test module moved to end of file (clippy `items_after_test_module`)
- README / config.example.toml / CLAUDE.md updated

## Scope limit (v1)

Re-mention verification scans issue comments only, not review-thread comments (documented in code).

## Verification

- `cargo build` / `cargo test` (293 passed, incl. new tests for dismiss roundtrip, mention boundary scanning, undismiss flow, role-branched notifications) / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` all green
